### PR TITLE
Fix compiler div-by-0 error when it encountered 1.0/0.0

### DIFF
--- a/test.c
+++ b/test.c
@@ -1,16 +1,16 @@
 /*
   Copyright (c) 2009 Dave Gamble
- 
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
- 
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
- 
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,7 +28,7 @@
 void doit(char *text)
 {
 	char *out;cJSON *json;
-	
+
 	json=cJSON_Parse(text);
 	if (!json) {printf("Error before: [%s]\n",cJSON_GetErrorPtr());}
 	else
@@ -44,7 +44,7 @@ void doit(char *text)
 void dofile(char *filename)
 {
 	FILE *f;long len;char *data;
-	
+
 	f=fopen(filename,"rb");fseek(f,0,SEEK_END);len=ftell(f);fseek(f,0,SEEK_SET);
 	data=(char*)malloc(len+1);fread(data,1,len,f);data[len]='\0';fclose(f);
 	doit(data);
@@ -68,11 +68,12 @@ void create_objects()
 	struct record fields[2]={
 		{"zip",37.7668,-1.223959e+2,"","SAN FRANCISCO","CA","94107","US"},
 		{"zip",37.371991,-1.22026e+2,"","SUNNYVALE","CA","94085","US"}};
+	volatile double zero = 0.0;
 
 	/* Here we construct some JSON standards, from the JSON site. */
-	
+
 	/* Our "Video" datatype: */
-	root=cJSON_CreateObject();	
+	root=cJSON_CreateObject();
 	cJSON_AddItemToObject(root, "name", cJSON_CreateString("Jack (\"Bee\") Nimble"));
 	cJSON_AddItemToObject(root, "format", fmt=cJSON_CreateObject());
 	cJSON_AddStringToObject(fmt,"type",		"rect");
@@ -80,7 +81,7 @@ void create_objects()
 	cJSON_AddNumberToObject(fmt,"height",		1080);
 	cJSON_AddFalseToObject (fmt,"interlace");
 	cJSON_AddNumberToObject(fmt,"frame rate",	24);
-	
+
 	out=cJSON_Print(root);	cJSON_Delete(root);	printf("%s\n",out);	free(out);	/* Print to text, Delete the cJSON, print it, release the string. */
 
 	/* Our "days of the week" array: */
@@ -93,7 +94,7 @@ void create_objects()
 	for (i=0;i<3;i++) cJSON_AddItemToArray(root,cJSON_CreateIntArray(numbers[i],3));
 
 /*	cJSON_ReplaceItemInArray(root,1,cJSON_CreateString("Replacement")); */
-	
+
 	out=cJSON_Print(root);	cJSON_Delete(root);	printf("%s\n",out);	free(out);
 
 
@@ -126,19 +127,19 @@ void create_objects()
 		cJSON_AddStringToObject(fld, "Zip", fields[i].zip);
 		cJSON_AddStringToObject(fld, "Country", fields[i].country);
 	}
-	
+
 /*	cJSON_ReplaceItemInObject(cJSON_GetArrayItem(root,1),"City",cJSON_CreateIntArray(ids,4)); */
-	
+
 	out=cJSON_Print(root);	cJSON_Delete(root);	printf("%s\n",out);	free(out);
 
 	root=cJSON_CreateObject();
-	cJSON_AddNumberToObject(root,"number", 1.0/0.0);
+	cJSON_AddNumberToObject(root,"number", 1.0/zero);
 	out=cJSON_Print(root);	cJSON_Delete(root);	printf("%s\n",out);	free(out);
 }
 
 int main (int argc, const char * argv[]) {
 	/* a bunch of json: */
-	char text1[]="{\n\"name\": \"Jack (\\\"Bee\\\") Nimble\", \n\"format\": {\"type\":       \"rect\", \n\"width\":      1920, \n\"height\":     1080, \n\"interlace\":  false,\"frame rate\": 24\n}\n}";	
+	char text1[]="{\n\"name\": \"Jack (\\\"Bee\\\") Nimble\", \n\"format\": {\"type\":       \"rect\", \n\"width\":      1920, \n\"height\":     1080, \n\"interlace\":  false,\"frame rate\": 24\n}\n}";
 	char text2[]="[\"Sunday\", \"Monday\", \"Tuesday\", \"Wednesday\", \"Thursday\", \"Friday\", \"Saturday\"]";
 	char text3[]="[\n    [0, -1, 0],\n    [1, 0, 0],\n    [0, 0, 1]\n	]\n";
 	char text4[]="{\n		\"Image\": {\n			\"Width\":  800,\n			\"Height\": 600,\n			\"Title\":  \"View from 15th Floor\",\n			\"Thumbnail\": {\n				\"Url\":    \"http:/*www.example.com/image/481989943\",\n				\"Height\": 125,\n				\"Width\":  \"100\"\n			},\n			\"IDs\": [116, 943, 234, 38793]\n		}\n	}";
@@ -163,7 +164,7 @@ int main (int argc, const char * argv[]) {
 
 	/* Process each json textblock by parsing, then rebuilding: */
 	doit(text1);
-	doit(text2);	
+	doit(text2);
 	doit(text3);
 	doit(text4);
 	doit(text5);
@@ -179,6 +180,6 @@ int main (int argc, const char * argv[]) {
 
 	/* Now some samplecode for building objects concisely: */
 	create_objects();
-	
+
 	return 0;
 }


### PR DESCRIPTION
Tricked the compiler to use volatile local variable zero instead, so it does not know for sure whether or not it's going to be zero.

Sorry, I have my editor to remove all trailing whitespaces automatically, so it has those fixed too.
