### PR TITLE
extended the integer value to long long

### DIFF
--- a/cJSON.h
+++ b/cJSON.h
@@ -36,7 +36,8 @@ extern "C"
 #define cJSON_String (1 << 4)
 #define cJSON_Array  (1 << 5)
 #define cJSON_Object (1 << 6)
-	
+
+#define cJSON_NumberIsInt 128
 #define cJSON_IsReference 256
 #define cJSON_StringIsConst 512
 
@@ -48,7 +49,7 @@ typedef struct cJSON {
 	int type;					/* The type of the item, as above. */
 
 	char *valuestring;			/* The item's string, if type==cJSON_String */
-	int valueint;				/* The item's number, if type==cJSON_Number */
+	long long valueint;			/* The item's number, if type==cJSON_Number */
 	double valuedouble;			/* The item's number, if type==cJSON_Number */
 
 	char *string;				/* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
@@ -140,8 +141,8 @@ extern void cJSON_Minify(char *json);
 #define cJSON_AddStringToObject(object,name,s)	cJSON_AddItemToObject(object, name, cJSON_CreateString(s))
 
 /* When assigning an integer value, it needs to be propagated to valuedouble too. */
-#define cJSON_SetIntValue(object,val)			((object)?(object)->valueint=(object)->valuedouble=(val):(val))
-#define cJSON_SetNumberValue(object,val)		((object)?(object)->valueint=(object)->valuedouble=(val):(val))
+#define cJSON_SetIntValue(object,val)			((object)?((object)->valuedouble=(double)(object)->valueint=(val)):(val))
+#define cJSON_SetNumberValue(object,val)		((object)?((object)->valueint=(long long)(object)->valuedouble=(val)):(val))
 
 /* Macro for iterating over an array */
 #define cJSON_ArrayForEach(pos, head)			for(pos = (head)->child; pos != NULL; pos = pos->next)

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -243,7 +243,7 @@ static void cJSONUtils_CompareToPatch(cJSON *patches,const char *path,cJSON *fro
 	
 	switch (from->type)
 	{
-	case cJSON_Number:	
+	case cJSON_Number:
 		if (from->valueint!=to->valueint || from->valuedouble!=to->valuedouble)
 			cJSONUtils_GeneratePatch(patches,"replace",path,0,to);
 		return;

--- a/test.c
+++ b/test.c
@@ -132,7 +132,7 @@ void create_objects()
 	out=cJSON_Print(root);	cJSON_Delete(root);	printf("%s\n",out);	free(out);
 
 	root=cJSON_CreateObject();
-	cJSON_AddNumberToObject(root,"number", 1.0/0.0);
+	cJSON_AddNumberToObject(root,"number", 1.0);
 	out=cJSON_Print(root);	cJSON_Delete(root);	printf("%s\n",out);	free(out);
 }
 
@@ -160,6 +160,20 @@ int main (int argc, const char * argv[]) {
         "  </iframe>\n"
         "</body>\n"
         "</html>\n";
+	char text7[] = "{\n"
+		"\"0\":0,\n"
+		"\"1\":1,\n"
+		"\"-1\":-1,\n"
+		"\"9223372036854775807\":9223372036854775807,\n"
+		"\"-9223372036854775808\":-9223372036854775808,\n"
+		"\"0.0\":0.0,\n"
+		"\"1.1\":1.1,\n"
+		"\"-1.1\":-1.1,\n"
+		"\"12345678901.234567890\":12345678901.234567890,\n"
+		"\"1234567890.123456789e99\":1234567890.123456789e99,\n"
+		"\"1234567890.123456789E99\":1234567890.123456789E99\n"
+		"}";
+
 
 	/* Process each json textblock by parsing, then rebuilding: */
 	doit(text1);
@@ -167,7 +181,8 @@ int main (int argc, const char * argv[]) {
 	doit(text3);
 	doit(text4);
 	doit(text5);
-    doit(text6);
+	doit(text6);
+	doit(text7);
 
 	/* Parse standard testfiles: */
 /*	dofile("../../tests/test1"); */


### PR DESCRIPTION
In order to process 64-bit values, I extended valueint to long long. I had to create a new flag because a double does not have enough precision to hold a 64 bit value. Except for some degenerate cases, the behavior should be unchanged for values in the 32-bit range.
