### PR TITLE
Getting objects via dot notation

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -677,6 +677,27 @@ cJSON *cJSON_GetArrayItem(cJSON *array,int item)				{cJSON *c=array?array->child
 cJSON *cJSON_GetObjectItem(cJSON *object,const char *string)	{cJSON *c=object?object->child:0;while (c && cJSON_strcasecmp(c->string,string)) c=c->next; return c;}
 int cJSON_HasObjectItem(cJSON *object,const char *string)		{return cJSON_GetObjectItem(object,string)?1:0;}
 
+cJSON *cJSON_GetDotObjectItem(cJSON *object,const char *string) {
+    int node_name_length;
+    char *node_name;
+    const char *position;
+        
+    position = strchr(string, '.');
+    if (position != NULL) {
+        node_name_length = position - string;
+        node_name = (char*)cJSON_malloc(node_name_length + 1);
+        strncpy(node_name, string, node_name_length);
+
+        object = cJSON_GetObjectItem(object, node_name);
+        cJSON_free(node_name);
+
+        return cJSON_GetDotObjectItem(object, position + 1);
+    }
+    else {
+        return cJSON_GetObjectItem(object, string);
+    }
+}
+
 /* Utility for array list handling. */
 static void suffix_object(cJSON *prev,cJSON *item) {prev->next=item;item->prev=prev;}
 /* Utility for handling references. */

--- a/cJSON.c
+++ b/cJSON.c
@@ -61,17 +61,20 @@ static int cJSON_strcasecmp(const char *s1, const char *s2)
     return tolower(*(const unsigned char *)s1) - tolower(*(const unsigned char *)s2);
 }
 
-static int cJSON_strncasecmp(const char *s1, const char *s2, int comparelen)
+static int cJSON_strncasecmp(const char *s1, const char *s2, size_t comparelen)
 {
-    int i;
-    if (!s1) {
+    if (!s1)
+    {
         return (s1 == s2) ? 0 : 1;
     }
-    if (!s2) {
+    if (!s2)
+    {
         return 1;
     }
-    for (i = 0; tolower(*s1) == tolower(*s2); ++s1, ++s2, ++i) {
-        if (*s1 == 0 || i + 1 == comparelen) {
+    for (; tolower(*s1) == tolower(*s2); ++s1, ++s2, comparelen--)
+    {
+        if (*s1 == 0 || comparelen == 1)
+        {
             return 0;
         }
     }
@@ -1632,31 +1635,42 @@ cJSON *cJSON_GetObjectItem(cJSON *object, const char *string)
     return c;
 }
 
-int cJSON_HasObjectItem(cJSON *object,const char *string)
+cJSON *cJSON_GetSizedObjectItem(cJSON *object, const char *string, size_t length)
 {
-    return cJSON_GetObjectItem(object, string) ? 1 : 0;
-}
-
-cJSON *cJSON_GetSizedObjectItem(cJSON *object,const char *string, int length) {
     cJSON *c = object ? object->child : 0;
     while (c && cJSON_strncasecmp(c->string, string, length))
+    {
         c = c->next;
+    }
     return c;
 }
 
-cJSON *cJSON_GetDotObjectItem(cJSON *object,const char *string) {
-    int node_name_length;
+cJSON *cJSON_GetDotObjectItem(cJSON *object, const char *string)
+{
+    size_t node_name_length;
     const char *position;
  
     position = strchr(string, '.');
-    if (position != NULL) {
+    if (position != NULL)
+    {
         node_name_length = position - string;
         object = cJSON_GetSizedObjectItem(object, string, node_name_length);
         return cJSON_GetDotObjectItem(object, position + 1);
     }
-    else {
+    else
+    {
         return cJSON_GetObjectItem(object, string);
     }
+}
+
+int cJSON_HasObjectItem(cJSON *object, const char *string)
+{
+    return cJSON_GetObjectItem(object, string) ? 1 : 0;
+}
+
+int cJSON_HasDotObjectItem(cJSON *object, const char* string)
+{
+    return cJSON_GetDotObjectItem(object, string) ? 1 : 0;
 }
 
 /* Utility for array list handling. */

--- a/cJSON.h
+++ b/cJSON.h
@@ -92,6 +92,8 @@ extern cJSON *cJSON_GetArrayItem(cJSON *array, int item);
 extern cJSON *cJSON_GetObjectItem(cJSON *object, const char *string);
 extern cJSON *cJSON_GetDotObjectItem(cJSON *object, const char *string);
 extern int cJSON_HasObjectItem(cJSON *object, const char *string);
+extern int cJSON_HasDotObjectItem(cJSON *object, const char* string);
+
 /* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds. */
 extern const char *cJSON_GetErrorPtr(void);
 	

--- a/cJSON.h
+++ b/cJSON.h
@@ -81,6 +81,7 @@ extern cJSON *cJSON_GetArrayItem(cJSON *array,int item);
 /* Get item "string" from object. Case insensitive. */
 extern cJSON *cJSON_GetObjectItem(cJSON *object,const char *string);
 extern int cJSON_HasObjectItem(cJSON *object,const char *string);
+extern cJSON *cJSON_GetDotObjectItem(cJSON *object,const char *string);
 /* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds. */
 extern const char *cJSON_GetErrorPtr(void);
 	


### PR DESCRIPTION
Added functionality which makes accessing child objects via struct-like dot notation possible.
So that, for example, the README-example

```
cJSON * format = cJSON_GetObjectItem(root,"format");`
int framerate = cJSON_GetObjectItem(format,"frame rate")->valueint;`
```

could instead be expressed as:

```
int framerate = cJSON_GetDotObjectItem(root, "format.frame rate")->valueint;
```
