### PR TITLE
Add const qualifiers

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -257,7 +257,7 @@ static char* ensure(printbuffer *p, int needed)
 }
 
 /* calculate the new length of the string in a printbuffer */
-static int update(printbuffer *p)
+static int update(const printbuffer *p)
 {
     char *str;
     if (!p || !p->buffer)
@@ -270,7 +270,7 @@ static int update(printbuffer *p)
 }
 
 /* Render the number nicely from the given item into a string. */
-static char *print_number(cJSON *item, printbuffer *p)
+static char *print_number(const cJSON *item, printbuffer *p)
 {
     char *str = 0;
     double d = item->valuedouble;
@@ -760,18 +760,18 @@ static char *print_string_ptr(const char *str, printbuffer *p)
 }
 
 /* Invoke print_string_ptr (which is useful) on an item. */
-static char *print_string(cJSON *item, printbuffer *p)
+static char *print_string(const cJSON *item, printbuffer *p)
 {
     return print_string_ptr(item->valuestring, p);
 }
 
 /* Predeclare these prototypes. */
 static const char *parse_value(cJSON *item, const char *value, const char **ep);
-static char *print_value(cJSON *item, int depth, int fmt, printbuffer *p);
+static char *print_value(const cJSON *item, int depth, int fmt, printbuffer *p);
 static const char *parse_array(cJSON *item, const char *value, const char **ep);
-static char *print_array(cJSON *item, int depth, int fmt, printbuffer *p);
+static char *print_array(const cJSON *item, int depth, int fmt, printbuffer *p);
 static const char *parse_object(cJSON *item, const char *value, const char **ep);
-static char *print_object(cJSON *item, int depth, int fmt, printbuffer *p);
+static char *print_object(const cJSON *item, int depth, int fmt, printbuffer *p);
 
 /* Utility to jump whitespace and cr/lf */
 static const char *skip(const char *in)
@@ -831,17 +831,17 @@ cJSON *cJSON_Parse(const char *value)
 }
 
 /* Render a cJSON item/entity/structure to text. */
-char *cJSON_Print(cJSON *item)
+char *cJSON_Print(const cJSON *item)
 {
     return print_value(item, 0, 1, 0);
 }
 
-char *cJSON_PrintUnformatted(cJSON *item)
+char *cJSON_PrintUnformatted(const cJSON *item)
 {
     return print_value(item, 0, 0, 0);
 }
 
-char *cJSON_PrintBuffered(cJSON *item, int prebuffer, int fmt)
+char *cJSON_PrintBuffered(const cJSON *item, int prebuffer, int fmt)
 {
     printbuffer p;
     p.buffer = (char*)cJSON_malloc(prebuffer);
@@ -899,7 +899,7 @@ static const char *parse_value(cJSON *item, const char *value, const char **ep)
 }
 
 /* Render a value to text. */
-static char *print_value(cJSON *item, int depth, int fmt, printbuffer *p)
+static char *print_value(const cJSON *item, int depth, int fmt, printbuffer *p)
 {
     char *out = 0;
 
@@ -1045,7 +1045,7 @@ static const char *parse_array(cJSON *item,const char *value,const char **ep)
 }
 
 /* Render an array to text */
-static char *print_array(cJSON *item, int depth, int fmt, printbuffer *p)
+static char *print_array(const cJSON *item, int depth, int fmt, printbuffer *p)
 {
     char **entries;
     char *out = 0;
@@ -1306,7 +1306,7 @@ static const char *parse_object(cJSON *item, const char *value, const char **ep)
 }
 
 /* Render an object to text. */
-static char *print_object(cJSON *item, int depth, int fmt, printbuffer *p)
+static char *print_object(const cJSON *item, int depth, int fmt, printbuffer *p)
 {
     char **entries = 0;
     char **names = 0;
@@ -1581,7 +1581,7 @@ static char *print_object(cJSON *item, int depth, int fmt, printbuffer *p)
 }
 
 /* Get Array size/item / object item. */
-int    cJSON_GetArraySize(cJSON *array)
+int    cJSON_GetArraySize(const cJSON *array)
 {
     cJSON *c = array->child;
     int i = 0;
@@ -1593,7 +1593,7 @@ int    cJSON_GetArraySize(cJSON *array)
     return i;
 }
 
-cJSON *cJSON_GetArrayItem(cJSON *array, int item)
+cJSON *cJSON_GetArrayItem(const cJSON *array, int item)
 {
     cJSON *c = array ? array->child : 0;
     while (c && item > 0)
@@ -1605,7 +1605,7 @@ cJSON *cJSON_GetArrayItem(cJSON *array, int item)
     return c;
 }
 
-cJSON *cJSON_GetObjectItem(cJSON *object, const char *string)
+cJSON *cJSON_GetObjectItem(const cJSON *object, const char *string)
 {
     cJSON *c = object ? object->child : 0;
     while (c && cJSON_strcasecmp(c->string, string))
@@ -1615,7 +1615,7 @@ cJSON *cJSON_GetObjectItem(cJSON *object, const char *string)
     return c;
 }
 
-int cJSON_HasObjectItem(cJSON *object,const char *string)
+int cJSON_HasObjectItem(const cJSON *object,const char *string)
 {
     return cJSON_GetObjectItem(object, string) ? 1 : 0;
 }
@@ -1628,7 +1628,7 @@ static void suffix_object(cJSON *prev, cJSON *item)
 }
 
 /* Utility for handling references. */
-static cJSON *create_reference(cJSON *item)
+static cJSON *create_reference(const cJSON *item)
 {
     cJSON *ref = cJSON_New_Item();
     if (!ref)
@@ -2052,7 +2052,7 @@ cJSON *cJSON_CreateStringArray(const char **strings, int count)
 }
 
 /* Duplication */
-cJSON *cJSON_Duplicate(cJSON *item, int recurse)
+cJSON *cJSON_Duplicate(const cJSON *item, int recurse)
 {
     cJSON *newitem;
     cJSON *cptr;

--- a/cJSON.h
+++ b/cJSON.h
@@ -76,21 +76,21 @@ extern void cJSON_InitHooks(cJSON_Hooks* hooks);
 /* Supply a block of JSON, and this returns a cJSON object you can interrogate. Call cJSON_Delete when finished. */
 extern cJSON *cJSON_Parse(const char *value);
 /* Render a cJSON entity to text for transfer/storage. Free the char* when finished. */
-extern char  *cJSON_Print(cJSON *item);
+extern char  *cJSON_Print(const cJSON *item);
 /* Render a cJSON entity to text for transfer/storage without any formatting. Free the char* when finished. */
-extern char  *cJSON_PrintUnformatted(cJSON *item);
+extern char  *cJSON_PrintUnformatted(const cJSON *item);
 /* Render a cJSON entity to text using a buffered strategy. prebuffer is a guess at the final size. guessing well reduces reallocation. fmt=0 gives unformatted, =1 gives formatted */
-extern char *cJSON_PrintBuffered(cJSON *item, int prebuffer, int fmt);
+extern char *cJSON_PrintBuffered(const cJSON *item, int prebuffer, int fmt);
 /* Delete a cJSON entity and all subentities. */
 extern void   cJSON_Delete(cJSON *c);
 
 /* Returns the number of items in an array (or object). */
-extern int	  cJSON_GetArraySize(cJSON *array);
+extern int	  cJSON_GetArraySize(const cJSON *array);
 /* Retrieve item number "item" from array "array". Returns NULL if unsuccessful. */
-extern cJSON *cJSON_GetArrayItem(cJSON *array, int item);
+extern cJSON *cJSON_GetArrayItem(const cJSON *array, int item);
 /* Get item "string" from object. Case insensitive. */
-extern cJSON *cJSON_GetObjectItem(cJSON *object, const char *string);
-extern int cJSON_HasObjectItem(cJSON *object, const char *string);
+extern cJSON *cJSON_GetObjectItem(const cJSON *object, const char *string);
+extern int cJSON_HasObjectItem(const cJSON *object, const char *string);
 /* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds. */
 extern const char *cJSON_GetErrorPtr(void);
 	
@@ -130,7 +130,7 @@ extern void cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newitem);
 extern void cJSON_ReplaceItemInObject(cJSON *object,const char *string,cJSON *newitem);
 
 /* Duplicate a cJSON item */
-extern cJSON *cJSON_Duplicate(cJSON *item, int recurse);
+extern cJSON *cJSON_Duplicate(const cJSON *item, int recurse);
 /* Duplicate will create a new, identical cJSON item to the one you pass, in new memory that will
 need to be released. With recurse!=0, it will duplicate any children connected to the item.
 The item->next and ->prev pointers are always zero on return from Duplicate. */


### PR DESCRIPTION
Print and query functions should not be able to modify the cJSON objects passed to them.
