### PR TITLE
Add pkg-config file support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,18 @@ add_library(${PROJ_CJSON_UTILS}.shared SHARED ${HEADERS_UTILS} ${SOURCES_UTILS})
 set_target_properties(${PROJ_CJSON_UTILS}.shared PROPERTIES OUTPUT_NAME cJSON_utils)
 target_link_libraries(${PROJ_CJSON_UTILS}.shared ${PROJ_CJSON}.shared)
 
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(libdir "${CMAKE_INSTALL_PREFIX}/lib")
+configure_file("${cJSON_SOURCE_DIR}/libcJSON.pc.in"
+	             "${cJSON_BINARY_DIR}/libcJSON.pc" @ONLY)
+
 install (TARGETS ${PROJ_CJSON} DESTINATION lib${LIB_SUFFIX})
 install (TARGETS ${PROJ_CJSON}.shared DESTINATION lib${LIB_SUFFIX})
 install (FILES cJSON.h DESTINATION include/cJSON)
 install (TARGETS ${PROJ_CJSON_UTILS} DESTINATION lib${LIB_SUFFIX})
 install (TARGETS ${PROJ_CJSON_UTILS}.shared DESTINATION lib${LIB_SUFFIX})
 install (FILES cJSON_Utils.h DESTINATION include/cJSON)
+install (FILES ${cJSON_BINARY_DIR}/libcJSON.pc DESTINATION lib/pkgconfig)
 
 option(ENABLE_CJSON_TEST "Enable building cJSON test" OFF)
 if(ENABLE_CJSON_TEST)

--- a/libcJSON.pc.in
+++ b/libcJSON.pc.in
@@ -1,0 +1,9 @@
+prefix=@prefix@
+libdir=@libdir@
+includedir=${prefix}/include/cJSON
+
+Name: libcJSON
+Version: 1.0
+Description: Ultralightweight JSON parser in ANSI C
+Libs: -L${libdir} -lcJSON
+Cflags: -I${includedir}


### PR DESCRIPTION
We configure and install a pkg-config file so that our compilation and
linking flags can be more easily found using pkg-config.
