### PR TITLE
Remove redundant test from cJSON_AddItemToArray

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -1658,7 +1658,7 @@ void   cJSON_AddItemToArray(cJSON *array, cJSON *item)
     else
     {
         /* append to the end */
-        while (c && c->next)
+        while (c->next)
         {
             c = c->next;
         }


### PR DESCRIPTION
The test for whether "c" is null is redundant.  Since this is the else case of "(!c)", and the only way "c" is changed is by the instruction assigning it "c->next" on the condition here, simply verifying that "c->next" isn't null is sufficient.
