### PR TITLE
don't ignore malloc failure in cJSON_PrintBuffered

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -845,6 +845,10 @@ char *cJSON_PrintBuffered(const cJSON *item, int prebuffer, int fmt)
 {
     printbuffer p;
     p.buffer = (char*)cJSON_malloc(prebuffer);
+    if (!p.buffer)
+    {
+        return 0;
+    }
     p.length = prebuffer;
     p.offset = 0;
 


### PR DESCRIPTION
Not a big deal, but this was picked up by a static analysis tool. Added for consistency with all of the other `malloc` calls which do some form of OOM checking.
