### PR TITLE
ARM Compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ $(DYLIBNAME): $(OBJ)
 		$(DYLIBCMD) $< $(LDFLAGS)
 	
 $(STLIBNAME): $(OBJ)
-		ar rcs $@ $<
+		$(AR) rcs $@ $<
 
 $(OBJ): cJSON.c cJSON.h 
 

--- a/cJSON.c
+++ b/cJSON.c
@@ -50,7 +50,7 @@ static int cJSON_strcasecmp(const char *s1, const char *s2)
     {
         return 1;
     }
-    for(; tolower(*s1) == tolower(*s2); ++s1, ++s2)
+    for(; tolower(*(const unsigned char *)s1) == tolower(*(const unsigned char *)s2); ++s1, ++s2)
     {
         if (*s1 == 0)
         {


### PR DESCRIPTION
When using arm-none-eabi-gcc as the exported C compiler, this warning was being thrown.
```
$ make
arm-none-eabi-gcc -ansi -pedantic -c -fpic  -Wall -Werror -Wstrict-prototypes -Wwrite-strings -D_POSIX_C_SOURCE=200112L cJSON.c
cJSON.c: In function 'cJSON_strcasecmp':
cJSON.c:53:5: error: array subscript has type 'char' [-Werror=char-subscripts]
     for(; tolower(*s1) == tolower(*s2); ++s1, ++s2)
     ^
cJSON.c:53:5: error: array subscript has type 'char' [-Werror=char-subscripts]
cc1: all warnings being treated as errors
Makefile:47: recipe for target 'cJSON.o' failed
make: *** [cJSON.o] Error 1
```
The variables being passed tolower are now cast to `const unsigned char*` which is consistent with the return statement at the end of the function.

The $(AR) variable should be used when creating a static library so that other archive tools can be exported.