### PR TITLE
Added a function to print to pre-allocated buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,8 @@ $(UTILS_STATIC): $(UTILS_OBJ)
 $(CJSON_SHARED_VERSION): $(CJSON_OBJ)
 	$(CC) -shared -o $@ $< $(LDFLAGS)
 #cJSON_Utils
-$(UTILS_SHARED_VERSION): $(UTILS_OBJ)
-	$(CC) -shared -o $@ $< $(LDFLAGS)
+$(UTILS_SHARED_VERSION): $(UTILS_OBJ) $(CJSON_OBJ)
+	$(CC) -shared -o $@ $< $(CJSON_OBJ) $(LDFLAGS)
 
 #objects
 #cJSON

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ INSTALL_LIBRARY_PATH = $(DESTDIR)$(PREFIX)/$(LIBRARY_PATH)
 
 INSTALL ?= cp -a
 
-R_CFLAGS = -fPIC -std=c89 -pedantic -Wall -Werror -Wstrict-prototypes -Wwrite-strings $(CFLAGS)
+R_CFLAGS = -fPIC -std=c89 -pedantic -Wall -Werror -Wstrict-prototypes -Wwrite-strings -Wshadow -Winit-self -Wcast-align -Wformat=2 -Wmissing-prototypes $(CFLAGS)
 
 uname := $(shell sh -c 'uname -s 2>/dev/null || echo false')
 
@@ -48,8 +48,6 @@ UTILS_SHARED_VERSION = $(UTILS_LIBNAME).$(SHARED).$(LIBVERSION)
 UTILS_SHARED_SO = $(UTILS_LIBNAME).$(SHARED).$(UTILS_SOVERSION)
 UTILS_STATIC = $(UTILS_LIBNAME).$(STATIC)
 
-SHARED_CMD = $(CC) -shared -o
-
 .PHONY: all shared static tests clean install
 
 all: shared static tests
@@ -65,15 +63,15 @@ test: tests
 	./$(UTILS_TEST)
 
 .c.o:
-	$(CC) -ansi -pedantic -c $(R_CFLAGS) $<
+	$(CC) -c $(R_CFLAGS) $<
 
 #tests
 #cJSON
 $(CJSON_TEST): $(CJSON_TEST_SRC) cJSON.h
-	$(CC) $(CJSON_TEST_SRC)  -o $@ $(LDLIBS) -I.
+	$(CC) $(R_CFLAGS) $(CJSON_TEST_SRC) -o $@ $(LDLIBS) -I.
 #cJSON_Utils
 $(UTILS_TEST): $(UTILS_TEST_SRC) cJSON.h cJSON_Utils.h
-	$(CC) $(UTILS_TEST_SRC) -o $@ $(LDLIBS) -I.
+	$(CC) $(R_CFLAGS) $(UTILS_TEST_SRC) -o $@ $(LDLIBS) -I.
 
 #static libraries
 #cJSON
@@ -86,10 +84,10 @@ $(UTILS_STATIC): $(UTILS_OBJ)
 #shared libraries .so.1.0.0
 #cJSON
 $(CJSON_SHARED_VERSION): $(CJSON_OBJ)
-	$(CC) -shared -o $@ $< $(LDFLAGS)
+	$(CC) $(R_CFLAGS) -shared -o $@ $< $(LDFLAGS)
 #cJSON_Utils
 $(UTILS_SHARED_VERSION): $(UTILS_OBJ) $(CJSON_OBJ)
-	$(CC) -shared -o $@ $< $(CJSON_OBJ) $(LDFLAGS)
+	$(CC) $(R_CFLAGS) -shared -o $@ $< $(CJSON_OBJ) $(LDFLAGS)
 
 #objects
 #cJSON

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ UTILS_LIBNAME = libcjson_utils
 CJSON_TEST = cJSON_test
 UTILS_TEST = cJSON_test_utils
 
+CJSON_TEST_SRC = cJSON.c test.c
+UTILS_TEST_SRC = cJSON.c cJSON_Utils.c test_utils.c
+
 LDLIBS = -lm
 
 LIBVERSION = 1.0.2
@@ -66,11 +69,11 @@ test: tests
 
 #tests
 #cJSON
-$(CJSON_TEST): cJSON.c cJSON.h test.c
-	$(CC) $^ -o $@ $(LDLIBS) -I.
+$(CJSON_TEST): $(CJSON_TEST_SRC) cJSON.h
+	$(CC) $(CJSON_TEST_SRC)  -o $@ $(LDLIBS) -I.
 #cJSON_Utils
-$(UTILS_TEST): cJSON.c cJSON.h test.c
-	$(CC) $^ -o $@ $(LDLIBS) -I.
+$(UTILS_TEST): $(UTILS_TEST_SRC) cJSON.h cJSON_Utils.h
+	$(CC) $(UTILS_TEST_SRC) -o $@ $(LDLIBS) -I.
 
 #static libraries
 #cJSON

--- a/cJSON.c
+++ b/cJSON.c
@@ -893,7 +893,7 @@ char *cJSON_PrintBuffered(const cJSON *item, int prebuffer, cjbool fmt)
     return print_value(item, 0, fmt, &p);
 }
 
-int cJSON_PrintPreallocated(cJSON *item,char *buf, const size_t len, const cjbool fmt)
+int cJSON_PrintPreallocated(cJSON *item,char *buf, const int len, const cjbool fmt)
 {
     char *out;
     printbuffer p;

--- a/cJSON.c
+++ b/cJSON.c
@@ -886,6 +886,16 @@ char *cJSON_PrintBuffered(const cJSON *item, int prebuffer, cjbool fmt)
     return print_value(item, 0, fmt, &p);
 }
 
+int cJSON_PrintMallocedBuffer(cJSON *item,char *buf,const size_t len, cjbool fmt)
+{
+    char *out;
+    printbuffer p;
+    p.buffer = buf;
+    p.length = len;
+    p.offset = 0;
+    out = print_value(item,0,fmt,&p);
+    return (out != buf ? -1 : 0);
+}
 
 /* Parser core - when encountering text, process appropriately. */
 static const char *parse_value(cJSON *item, const char *value, const char **ep)

--- a/cJSON.c
+++ b/cJSON.c
@@ -895,14 +895,12 @@ char *cJSON_PrintBuffered(const cJSON *item, int prebuffer, cjbool fmt)
 
 int cJSON_PrintPreallocated(cJSON *item,char *buf, const int len, const cjbool fmt)
 {
-    char *out;
     printbuffer p;
     p.buffer = buf;
     p.length = len;
     p.offset = 0;
     p.noalloc = true;
-    out = print_value(item,0,fmt,&p);
-    return (out != buf ? -1 : 0);
+    return print_value(item,0,fmt,&p) != NULL;
 }
 
 /* Parser core - when encountering text, process appropriately. */

--- a/cJSON.c
+++ b/cJSON.c
@@ -1155,8 +1155,7 @@ static char *print_array(const cJSON *item, int depth, cjbool fmt, printbuffer *
         child = item->child;
         while (child && !fail)
         {
-            ptr = print_value(child, depth + 1, fmt, p);
-            if (!ptr)
+            if (!print_value(child, depth + 1, fmt, p))
             {
                 return NULL;
             }
@@ -1473,7 +1472,10 @@ static char *print_object(const cJSON *item, int depth, cjbool fmt, printbuffer 
             p->offset+=len;
 
             /* print value */
-            print_value(child, depth, fmt, p);
+            if (!print_value(child, depth, fmt, p))
+            {
+                return NULL;
+            };
             p->offset = update(p);
 
             /* print comma if not last */

--- a/cJSON.c
+++ b/cJSON.c
@@ -244,9 +244,8 @@ typedef struct
     char *buffer;
     int length;
     int offset;
-    int noalloc;
+    cjbool noalloc;
 } printbuffer;
-
 
 /* realloc printbuffer if necessary to have at least "needed" bytes more */
 static char* ensure(printbuffer *p, int needed)
@@ -273,7 +272,7 @@ static char* ensure(printbuffer *p, int needed)
     {
         cJSON_free(p->buffer);
         p->length = 0;
-        p->noalloc = 0;
+        p->noalloc = false;
         p->buffer = NULL;
 
         return NULL;
@@ -889,7 +888,7 @@ char *cJSON_PrintBuffered(const cJSON *item, int prebuffer, cjbool fmt)
     }
     p.length = prebuffer;
     p.offset = 0;
-    p.noalloc = 0;
+    p.noalloc = false;
 
     return print_value(item, 0, fmt, &p);
 }
@@ -901,7 +900,7 @@ int cJSON_PrintPreallocated(cJSON *item,char *buf, const size_t len, const cjboo
     p.buffer = buf;
     p.length = len;
     p.offset = 0;
-    p.noalloc = 1;
+    p.noalloc = true;
     out = print_value(item,0,fmt,&p);
     return (out != buf ? -1 : 0);
 }

--- a/cJSON.c
+++ b/cJSON.c
@@ -900,7 +900,7 @@ int cJSON_PrintPreallocated(cJSON *item,char *buf, const int len, const cjbool f
     p.length = len;
     p.offset = 0;
     p.noalloc = true;
-    return print_value(item,0,fmt,&p) != NULL;
+    return (print_value(item,0,fmt,&p) != NULL ? 0 : -1);
 }
 
 /* Parser core - when encountering text, process appropriately. */

--- a/cJSON.h
+++ b/cJSON.h
@@ -84,9 +84,9 @@ extern char  *cJSON_PrintUnformatted(const cJSON *item);
 /* Render a cJSON entity to text using a buffered strategy. prebuffer is a guess at the final size. guessing well reduces reallocation. fmt=0 gives unformatted, =1 gives formatted */
 extern char *cJSON_PrintBuffered(const cJSON *item, int prebuffer, int fmt);
 /* Render a cJSON entity to text using a buffer already allocated in memory with length buf_len */
-extern int cJSON_PrintMallocedBuffer(cJSON *item,char *buf,const size_t len, int fmt);
-/* Delete a cJSON entity and all subentities. */ 
-extern void   cJSON_Delete(cJSON *c); 
+extern int cJSON_PrintPreallocated(cJSON *item, char *buf, const size_t len, const int fmt);
+/* Delete a cJSON entity and all subentities. */
+extern void   cJSON_Delete(cJSON *c);
 
 /* Returns the number of items in an array (or object). */
 extern int	  cJSON_GetArraySize(const cJSON *array);

--- a/cJSON.h
+++ b/cJSON.h
@@ -83,8 +83,10 @@ extern char  *cJSON_Print(const cJSON *item);
 extern char  *cJSON_PrintUnformatted(const cJSON *item);
 /* Render a cJSON entity to text using a buffered strategy. prebuffer is a guess at the final size. guessing well reduces reallocation. fmt=0 gives unformatted, =1 gives formatted */
 extern char *cJSON_PrintBuffered(const cJSON *item, int prebuffer, int fmt);
-/* Delete a cJSON entity and all subentities. */
-extern void   cJSON_Delete(cJSON *c);
+/* Render a cJSON entity to text using a buffer already allocated in memory with length buf_len */
+extern int cJSON_PrintMallocedBuffer(cJSON *item,char *buf,const size_t len, int fmt);
+/* Delete a cJSON entity and all subentities. */ 
+extern void   cJSON_Delete(cJSON *c); 
 
 /* Returns the number of items in an array (or object). */
 extern int	  cJSON_GetArraySize(const cJSON *array);

--- a/cJSON.h
+++ b/cJSON.h
@@ -84,7 +84,7 @@ extern char  *cJSON_PrintUnformatted(const cJSON *item);
 /* Render a cJSON entity to text using a buffered strategy. prebuffer is a guess at the final size. guessing well reduces reallocation. fmt=0 gives unformatted, =1 gives formatted */
 extern char *cJSON_PrintBuffered(const cJSON *item, int prebuffer, int fmt);
 /* Render a cJSON entity to text using a buffer already allocated in memory with length buf_len */
-extern int cJSON_PrintPreallocated(cJSON *item, char *buf, const size_t len, const int fmt);
+extern int cJSON_PrintPreallocated(cJSON *item, char *buf, const int len, const int fmt);
 /* Delete a cJSON entity and all subentities. */
 extern void   cJSON_Delete(cJSON *c);
 

--- a/test.c
+++ b/test.c
@@ -82,6 +82,63 @@ struct record
     const char *country;
 };
 
+
+/* Create a bunch of objects as demonstration. */
+int print_preallocated(cJSON *root)
+{
+    /* declarations */
+    char *out = NULL;
+    char *buf = NULL;
+    char *buf_fail = NULL;
+    int len = 0;
+    int len_fail = 0;
+
+    /* formatted print */
+    out = cJSON_Print(root);
+
+    /* create buffer to succeed */
+    /* the extra 64 bytes are in case a floating point value is printed */
+    len = strlen(out) + 64;
+    buf = malloc(len);
+
+    /* create buffer to fail */
+    len_fail = strlen(out);
+    buf_fail = malloc(len_fail);
+
+    /* Print to buffer */
+    if (cJSON_PrintPreallocated(root, buf, len, 1) != 0) {
+        printf("cJSON_PrintPreallocated failed!\n");
+        if (strcmp(out, buf) != 0) {
+            printf("cJSON_PrintPreallocated not the same as cJSON_Print!\n");
+            printf("cJSON_Print result:\n%s\n", out);
+            printf("cJSON_PrintPreallocated result:\n%s\n", buf);
+        }
+        free(out);
+        free(buf_fail);
+        free(buf);
+        return -1;
+    }
+
+    /* success */
+    printf("%s\n", buf);
+
+    /* force it to fail */
+    if (cJSON_PrintPreallocated(root, buf_fail, len_fail, 1) == 0) {
+        printf("cJSON_PrintPreallocated failed to show error with insufficient memory!\n");
+        printf("cJSON_Print result:\n%s\n", out);
+        printf("cJSON_PrintPreallocated result:\n%s\n", buf_fail);
+        free(out);
+        free(buf_fail);
+        free(buf);
+        return -1;
+    }
+
+    free(out);
+    free(buf_fail);
+    free(buf);
+    return 0;
+}
+
 /* Create a bunch of objects as demonstration. */
 void create_objects(void)
 {

--- a/test.c
+++ b/test.c
@@ -148,7 +148,6 @@ void create_objects(void)
     cJSON *img = NULL;
     cJSON *thm = NULL;
     cJSON *fld = NULL;
-    char *out = NULL;
     int i = 0;
 
     /* Our "days of the week" array: */
@@ -210,21 +209,20 @@ void create_objects(void)
     cJSON_AddNumberToObject(fmt, "frame rate", 24);
 
     /* Print to text */
-    out = cJSON_Print(root);
-    /* Delete the cJSON */
+    if (print_preallocated(root) != 0) {
+        cJSON_Delete(root);
+        exit(EXIT_FAILURE);
+    }
     cJSON_Delete(root);
-    /* print it */
-    printf("%s\n",out);
-    /* release the string */
-    free(out);
 
     /* Our "days of the week" array: */
     root = cJSON_CreateStringArray(strings, 7);
 
-    out = cJSON_Print(root);
+    if (print_preallocated(root) != 0) {
+        cJSON_Delete(root);
+        exit(EXIT_FAILURE);
+    }
     cJSON_Delete(root);
-    printf("%s\n", out);
-    free(out);
 
     /* Our matrix: */
     root = cJSON_CreateArray();
@@ -235,11 +233,11 @@ void create_objects(void)
 
     /* cJSON_ReplaceItemInArray(root, 1, cJSON_CreateString("Replacement")); */
 
-    out = cJSON_Print(root);
+    if (print_preallocated(root) != 0) {
+        cJSON_Delete(root);
+        exit(EXIT_FAILURE);
+    }
     cJSON_Delete(root);
-    printf("%s\n", out);
-    free(out);
-
 
     /* Our "gallery" item: */
     root = cJSON_CreateObject();
@@ -253,13 +251,13 @@ void create_objects(void)
     cJSON_AddStringToObject(thm, "Width", "100");
     cJSON_AddItemToObject(img, "IDs", cJSON_CreateIntArray(ids, 4));
 
-    out = cJSON_Print(root);
+    if (print_preallocated(root) != 0) {
+        cJSON_Delete(root);
+        exit(EXIT_FAILURE);
+    }
     cJSON_Delete(root);
-    printf("%s\n", out);
-    free(out);
 
     /* Our array of "records": */
-
     root = cJSON_CreateArray();
     for (i = 0; i < 2; i++)
     {
@@ -276,61 +274,20 @@ void create_objects(void)
 
     /* cJSON_ReplaceItemInObject(cJSON_GetArrayItem(root, 1), "City", cJSON_CreateIntArray(ids, 4)); */
 
-    out = cJSON_Print(root);
-    printf("%s\n", out);
-
-    printf("Test cJSON_PrintPreallocated:\n");
-    /* create buffer */
-    size_t len = strlen(out) + 1;
-    char *buf = malloc(len);
-
-    /* create buffer to fail */
-    size_t len_fail = strlen(out);
-    char *buf_fail = malloc(len_fail);
-
-    free(out);
-
-    /* Print to buffer */
-    if (cJSON_PrintPreallocated(root, buf, len, 1) != 0) {
-        printf("cJSON_PrintPreallocated failed (but it should not have!)\n");
-        free(buf_fail);
-        free(buf);
+    if (print_preallocated(root) != 0) {
+        cJSON_Delete(root);
         exit(EXIT_FAILURE);
-    } else {
-        printf("cJSON_PrintPreallocated:\n%s\n", buf);
     }
-
-    /* unformatted output */
-    if (cJSON_PrintPreallocated(root, buf, len, 0) != 0) {
-        printf("cJSON_PrintPreallocated failed (but it should not have!)\n");
-        free(buf_fail);
-        free(buf);
-        exit(EXIT_FAILURE);
-    } else {
-        printf("cJSON_PrintPreallocated (unformatted):\n%s\n", buf);
-    }
-
-    free(buf);
-
-    /* force it to fail */
-    if (cJSON_PrintPreallocated(root, buf_fail, len_fail, 1) != 0) {
-        printf("cJSON_PrintPreallocated failed (as expected)\n");
-    } else {
-        printf("cJSON_PrintPreallocated worked (but it should have failed!)\n");
-        printf("cJSON_PrintPreallocated:\n%s\n", buf_fail);
-    }
-
-    free(buf_fail);
     cJSON_Delete(root);
 
     root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "number", 1.0 / zero);
-    out = cJSON_Print(root);
-    printf("%s\n", out);
+
+    if (print_preallocated(root) != 0) {
+        cJSON_Delete(root);
+        exit(EXIT_FAILURE);
+    }
     cJSON_Delete(root);
-
-    free(out);
-
 }
 
 int main(void)

--- a/test.c
+++ b/test.c
@@ -22,6 +22,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "cJSON.h"
 
 /* Parse text to JSON, then render back to text, and print! */
@@ -219,16 +220,60 @@ void create_objects(void)
     /* cJSON_ReplaceItemInObject(cJSON_GetArrayItem(root, 1), "City", cJSON_CreateIntArray(ids, 4)); */
 
     out = cJSON_Print(root);
-    cJSON_Delete(root);
     printf("%s\n", out);
+
+    printf("Test cJSON_PrintPreallocated:\n");
+    /* create buffer */
+    size_t len = strlen(out) + 1;
+    char *buf = malloc(len);
+
+    /* create buffer to fail */
+    size_t len_fail = strlen(out);
+    char *buf_fail = malloc(len_fail);
+
     free(out);
+
+    /* Print to buffer */
+    if (cJSON_PrintPreallocated(root, buf, len, 1) != 0) {
+        printf("cJSON_PrintPreallocated failed (but it should not have!)\n");
+        free(buf_fail);
+        free(buf);
+        exit(EXIT_FAILURE);
+    } else {
+        printf("cJSON_PrintPreallocated:\n%s\n", buf);
+    }
+
+    /* unformatted output */
+    if (cJSON_PrintPreallocated(root, buf, len, 0) != 0) {
+        printf("cJSON_PrintPreallocated failed (but it should not have!)\n");
+        free(buf_fail);
+        free(buf);
+        exit(EXIT_FAILURE);
+    } else {
+        printf("cJSON_PrintPreallocated (unformatted):\n%s\n", buf);
+    }
+
+    free(buf);
+
+    /* force it to fail */
+    if (cJSON_PrintPreallocated(root, buf_fail, len_fail, 1) != 0) {
+        printf("cJSON_PrintPreallocated failed (as expected)\n");
+    } else {
+        printf("cJSON_PrintPreallocated worked (but it should have failed!)\n");
+        printf("cJSON_PrintPreallocated:\n%s\n", buf_fail);
+    }
+
+    free(buf_fail);
+    cJSON_Delete(root);
 
     root = cJSON_CreateObject();
     cJSON_AddNumberToObject(root, "number", 1.0 / zero);
     out = cJSON_Print(root);
-    cJSON_Delete(root);
     printf("%s\n", out);
+    cJSON_Delete(root);
+
     free(out);
+
 }
 
 int main(void)


### PR DESCRIPTION
I added a function called `cJSON_PrintMallocedBuffer` to print output to a buffer instead of allocating memory internally. I'm made it so there aren't any calls to malloc when printing out a cJSON item.

I also fixed the Makefile to have the appropriate dependencies and only source files (no headers) being compiled for the tests. Otherwise, clang on Mac (and perhaps elsewhere) complains. 