### PR TITLE
Make print_preallocated static.

### DIFF
--- a/test.c
+++ b/test.c
@@ -86,7 +86,7 @@ struct record
 
 
 /* Create a bunch of objects as demonstration. */
-int print_preallocated(cJSON *root)
+static int print_preallocated(cJSON *root)
 {
     /* declarations */
     char *out = NULL;


### PR DESCRIPTION
Otherwise compilation failes due to missing prototypes.

I'd like to suggest to setup a continuous integration like travis CI to avoid such problems.
I'm eager to help on this.