### PR TITLE
RFC: Make string in struct cJSON const.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT
 option(ENABLE_CUSTOM_COMPILER_FLAGS "Enables custom compiler flags for Clang and GCC" ON)
 if (ENABLE_CUSTOM_COMPILER_FLAGS)
     if(("${CMAKE_C_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang"))
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c89 -pedantic -Wall -Wextra -Werror -Wstrict-prototypes -Wwrite-strings -Wshadow -Winit-self -Wcast-align -Wformat=2 -Wmissing-prototypes -Wstrict-overflow=2")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c89 -pedantic -Wall -Wextra -Werror -Wstrict-prototypes -Wwrite-strings -Wshadow -Winit-self -Wcast-align -Wformat=2 -Wmissing-prototypes -Wstrict-overflow=2 -Wcast-qual")
     endif()
 endif()
 

--- a/cJSON.c
+++ b/cJSON.c
@@ -81,7 +81,10 @@ static int cJSON_strcasecmp(const char *s1, const char *s2)
 }
 
 static void *(*cJSON_malloc)(size_t sz) = malloc;
-static void (*cJSON_free)(void *ptr) = free;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
+static void (*cJSON_free)(const void *ptr) = free;
+#pragma GCC diagnostic pop
 
 static char* cJSON_strdup(const char* str)
 {
@@ -104,12 +107,18 @@ void cJSON_InitHooks(cJSON_Hooks* hooks)
     {
         /* Reset hooks */
         cJSON_malloc = malloc;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
         cJSON_free = free;
+#pragma GCC diagnostic pop
         return;
     }
 
     cJSON_malloc = (hooks->malloc_fn) ? hooks->malloc_fn : malloc;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
     cJSON_free = (hooks->free_fn) ? hooks->free_fn : free;
+#pragma GCC diagnostic pop
 }
 
 /* Internal constructor. */
@@ -1756,7 +1765,7 @@ void   cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item)
     {
         cJSON_free(item->string);
     }
-    item->string = (char*)string;
+    item->string = string;
     item->type |= cJSON_StringIsConst;
     cJSON_AddItemToArray(object, item);
 }

--- a/cJSON.h
+++ b/cJSON.h
@@ -62,7 +62,7 @@ typedef struct cJSON
     double valuedouble;
 
     /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
-    char *string;
+    const char *string;
 } cJSON;
 
 typedef struct cJSON_Hooks


### PR DESCRIPTION
Const correctness is embedded software is a big deal. Typically strings are really stored in flash, so it is just not possible to change them.

The cast item->string = (char)string in cJSON_AddItemToObjectCS allows a programmer to write to item>string later on without a compiler warning. That's the reason why it makes sense to make the string member const.

The code really has no problems when doing so besides the nasty fact that free() does not allow to pass const pointers. Therefore the ugly pragma statements. Nevertheless, I'm always in favor to make the API clean and to handle the somehow incompatible parts inside the library.

I'm eager to hear comments.