### PR TITLE
Change len from int to unsigned in parse_string

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -480,7 +480,7 @@ static const char *parse_string(cJSON *item, const char *str, const char **ep)
     const char *end_ptr =str + 1;
     char *ptr2 = NULL;
     char *out = NULL;
-    int len = 0;
+    unsigned len = 0;
     unsigned uc = 0;
     unsigned uc2 = 0;
 


### PR DESCRIPTION
Fix "-Werror=strict-overflow compile error" following the first
suggestion of Danomi Manchego in
https://github.com/DaveGamble/cJSON/issues/85

Fixes:
 - http://autobuild.buildroot.net/results/3d899790acdc5c21733ff6f7f5a1b500e862ea0a

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>