### PR TITLE
Suggestion: use typedef enum

### DIFF
--- a/cJSON.h
+++ b/cJSON.h
@@ -31,14 +31,24 @@ extern "C"
 #include <stddef.h>
 
 /* cJSON Types: */
-#define cJSON_False  (1 << 0)
-#define cJSON_True   (1 << 1)
-#define cJSON_NULL   (1 << 2)
-#define cJSON_Number (1 << 3)
-#define cJSON_String (1 << 4)
-#define cJSON_Array  (1 << 5)
-#define cJSON_Object (1 << 6)
-#define cJSON_Raw    (1 << 7) /* raw json */
+//#define cJSON_False  (1 << 0)
+//#define cJSON_True   (1 << 1)
+//#define cJSON_NULL   (1 << 2)
+//#define cJSON_Number (1 << 3)
+//#define cJSON_String (1 << 4)
+//#define cJSON_Array  (1 << 5)
+//#define cJSON_Object (1 << 6)
+//#define cJSON_Raw    (1 << 7) /* raw json */
+  
+  typedef enum {
+	cJSON_False =   (1 << 0),
+	cJSON_True =    (1 << 1),
+	cJSON_NULL =    (1 << 2),
+	cJSON_Number =  (1 << 3),
+	cJSON_String =  (1 << 4),
+	cJSON_Array =   (1 << 5),
+	cJSON_Object =  (1 << 6)
+}cJSON_Types;
 
 #define cJSON_IsReference 256
 #define cJSON_StringIsConst 512
@@ -53,7 +63,7 @@ typedef struct cJSON
     struct cJSON *child;
 
     /* The type of the item, as above. */
-    int type;
+    cJSON_Types type;
 
     /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
     char *valuestring;

--- a/cJSON.h
+++ b/cJSON.h
@@ -47,7 +47,8 @@ extern "C"
 	cJSON_Number =  (1 << 3),
 	cJSON_String =  (1 << 4),
 	cJSON_Array =   (1 << 5),
-	cJSON_Object =  (1 << 6)
+	cJSON_Object =  (1 << 6),
+	cJSON_Raw =  	(1 << 7)
 }cJSON_Types;
 
 #define cJSON_IsReference 256


### PR DESCRIPTION
To make debugging easier, I suggest to use a typedef enum instead of raw int defines.
This way, the object type shows in human readable form during debugging.