### PR TITLE
Add more compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ if (ENABLE_CUSTOM_COMPILER_FLAGS)
         -Wc++-compat
         -fstack-protector-strong
         -Wcomma
+        -Wdouble-promotion
         )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ if (ENABLE_CUSTOM_COMPILER_FLAGS)
         -fstack-protector-strong
         -Wcomma
         -Wdouble-promotion
+        -Wparentheses
         )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ if (ENABLE_CUSTOM_COMPILER_FLAGS)
         -Wconversion
         -Wc++-compat
         -fstack-protector-strong
+        -Wcomma
         )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Example:
 
     main()
     {
-        if (TEST_PROTECT() == 0)
+        if (TEST_PROTECT())
         {
             MyTest();
         }
     }
 
-If MyTest calls `TEST_ABORT`, program control will immediately return to `TEST_PROTECT` with a non-zero return value.
+If MyTest calls `TEST_ABORT`, program control will immediately return to `TEST_PROTECT` with a return value of zero.
 
 
 Unity Assertion Summary

--- a/cJSON.c
+++ b/cJSON.c
@@ -1914,7 +1914,7 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count)
 
     for(i = 0; a && (i < (size_t)count); i++)
     {
-        n = cJSON_CreateNumber(numbers[i]);
+        n = cJSON_CreateNumber((double)numbers[i]);
         if(!n)
         {
             cJSON_Delete(a);

--- a/cJSON.c
+++ b/cJSON.c
@@ -68,7 +68,7 @@ static int cJSON_strcasecmp(const unsigned char *s1, const unsigned char *s2)
     {
         return 1;
     }
-    for(; tolower(*s1) == tolower(*s2); ++s1, ++s2)
+    for(; tolower(*s1) == tolower(*s2); (void)++s1, ++s2)
     {
         if (*s1 == '\0')
         {
@@ -731,7 +731,7 @@ static unsigned char *print_string_ptr(const unsigned char * const input, printb
     output[0] = '\"';
     output_pointer = output + 1;
     /* copy the string */
-    for (input_pointer = input; *input_pointer != '\0'; input_pointer++, output_pointer++)
+    for (input_pointer = input; *input_pointer != '\0'; (void)input_pointer++, output_pointer++)
     {
         if ((*input_pointer > 31) && (*input_pointer != '\"') && (*input_pointer != '\\'))
         {

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -31,7 +31,7 @@ static int cJSONUtils_strcasecmp(const unsigned char *s1, const unsigned char *s
     {
         return 1;
     }
-    for(; tolower(*s1) == tolower(*s2); ++s1, ++s2)
+    for(; tolower(*s1) == tolower(*s2); (void)++s1, ++s2)
     {
         if(*s1 == 0)
         {
@@ -49,7 +49,7 @@ static int cJSONUtils_Pstrcasecmp(const unsigned char *a, const unsigned char *e
     {
         return (a == e) ? 0 : 1; /* both NULL? */
     }
-    for (; *a && *e && (*e != '/'); a++, e++) /* compare until next '/' */
+    for (; *a && *e && (*e != '/'); (void)a++, e++) /* compare until next '/' */
     {
         if (*e == '~')
         {
@@ -81,7 +81,7 @@ static int cJSONUtils_Pstrcasecmp(const unsigned char *a, const unsigned char *e
 static size_t cJSONUtils_PointerEncodedstrlen(const unsigned char *s)
 {
     size_t l = 0;
-    for (; *s; s++, l++)
+    for (; *s; (void)s++, l++)
     {
         if ((*s == '~') || (*s == '/'))
         {
@@ -127,7 +127,7 @@ CJSON_PUBLIC(char *) cJSONUtils_FindPointerFromObjectTo(cJSON *object, cJSON *ta
     }
 
     /* recursively search all children of the object */
-    for (obj = object->child; obj; obj = obj->next, c++)
+    for (obj = object->child; obj; (void)(obj = obj->next), c++)
     {
         unsigned char *found = (unsigned char*)cJSONUtils_FindPointerFromObjectTo(obj, target);
         if (found)
@@ -226,7 +226,7 @@ static void cJSONUtils_InplaceDecodePointerString(unsigned char *string)
         return;
     }
 
-    for (; *string; s2++, string++)
+    for (; *string; (void)s2++, string++)
     {
         *s2 = (*string != '~')
             ? (*string)
@@ -298,7 +298,7 @@ static int cJSONUtils_Compare(cJSON *a, cJSON *b)
             /* string mismatch. */
             return (strcmp(a->valuestring, b->valuestring) != 0) ? -3 : 0;
         case cJSON_Array:
-            for (a = a->child, b = b->child; a && b; a = a->next, b = b->next)
+            for ((void)(a = a->child), b = b->child; a && b; (void)(a = a->next), b = b->next)
             {
                 int err = cJSONUtils_Compare(a, b);
                 if (err)
@@ -589,7 +589,7 @@ static void cJSONUtils_CompareToPatch(cJSON *patches, const unsigned char *path,
             size_t c = 0;
             unsigned char *newpath = (unsigned char*)malloc(strlen((const char*)path) + 23); /* Allow space for 64bit int. */
             /* generate patches for all array elements that exist in "from" and "to" */
-            for (c = 0, from = from->child, to = to->child; from && to; from = from->next, to = to->next, c++)
+            for ((void)(c = 0), (void)(from = from->child), to = to->child; from && to; (void)(from = from->next), (void)(to = to->next), c++)
             {
                 /* check if conversion to unsigned long is valid
                  * This should be eliminated at compile time by dead code elimination
@@ -603,7 +603,7 @@ static void cJSONUtils_CompareToPatch(cJSON *patches, const unsigned char *path,
                 cJSONUtils_CompareToPatch(patches, newpath, from, to);
             }
             /* remove leftover elements from 'from' that are not in 'to' */
-            for (; from; from = from->next, c++)
+            for (; from; (void)(from = from->next), c++)
             {
                 /* check if conversion to unsigned long is valid
                  * This should be eliminated at compile time by dead code elimination
@@ -617,7 +617,7 @@ static void cJSONUtils_CompareToPatch(cJSON *patches, const unsigned char *path,
                 cJSONUtils_GeneratePatch(patches, (const unsigned char*)"remove", path, newpath, 0);
             }
             /* add new elements in 'to' that were not in 'from' */
-            for (; to; to = to->next, c++)
+            for (; to; (void)(to = to->next), c++)
             {
                 cJSONUtils_GeneratePatch(patches, (const unsigned char*)"add", path, (const unsigned char*)"-", to);
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,13 @@
 add_library(unity unity/src/unity.c)
 
 if(ENABLE_CJSON_TEST)
+
+    # Disable -Werror for Unity
+    list(FIND custom_compiler_flags "-Werror" werror_found)
+    if (werror_found)
+        target_compile_options(unity PRIVATE "-Wno-error")
+    endif()
+
     #copy test files
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/inputs")
     file(GLOB test_files "inputs/*")

--- a/tests/parse_array.c
+++ b/tests/parse_array.c
@@ -124,7 +124,7 @@ static void parse_array_should_parse_arrays_with_multiple_elements(void)
                 i = 0;
                 (i < (sizeof(expected_types)/sizeof(int)))
                 && (node != NULL);
-                i++, node = node->next)
+                (void)i++, node = node->next)
         {
             TEST_ASSERT_BITS(0xFF, expected_types[i], node->type);
         }

--- a/tests/parse_object.c
+++ b/tests/parse_object.c
@@ -134,7 +134,7 @@ static void parse_object_should_parse_objects_with_multiple_elements(void)
                 i = 0;
                 (i < (sizeof(expected_types)/sizeof(int)))
                 && (node != NULL);
-                i++, node = node->next)
+                (void)i++, node = node->next)
         {
             assert_is_child(node, expected_names[i], expected_types[i]);
         }

--- a/tests/unity/src/unity.c
+++ b/tests/unity/src/unity.c
@@ -194,7 +194,7 @@ void UnityPrintNumberHex(const UNITY_UINT number, const char nibbles_to_print)
     while (nibbles > 0)
     {
         nibbles--;
-        nibble = (int)(number >> (nibbles * 4)) & 0x0F;
+        nibble = (number >> (nibbles * 4)) & 0x0F;
         if (nibble <= 9)
         {
             UNITY_OUTPUT_CHAR((char)('0' + nibble));


### PR DESCRIPTION
Adds the compiler flags `-Wcomma`, `-Wparentheses` and `-Wdouble-promotion`.

Also disables `-Werror` when building unity, so I don't have to maintain downstream patches that make compiler flags work with unity.