### PR TITLE
Parse buffer

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -177,6 +177,22 @@ CJSON_PUBLIC(void) cJSON_Delete(cJSON *c)
     }
 }
 
+typedef struct
+{
+    const unsigned char *content;
+    size_t length;
+    size_t offset;
+} parse_buffer;
+
+/* check if the given size is left to read in a given parse buffer (starting with 1) */
+#define can_read(buffer, size) ((buffer != NULL) && (((buffer)->offset + size) <= (buffer)->length))
+#define cannot_read(buffer, size) (!can_read(buffer, size))
+/* check if the buffer can be accessed at the given index (starting with 0) */
+#define can_access_at_index(buffer, index) ((buffer != NULL) && (((buffer)->offset + index) < (buffer)->length))
+#define cannot_access_at_index(buffer, index) (!can_access_at_index(buffer, index))
+/* get a pointer to the buffer at the position */
+#define buffer_at_offset(buffer) ((buffer)->content + (buffer)->offset)
+
 /* Parse the input text to generate a number, and populate the result into item. */
 static const unsigned char *parse_number(cJSON * const item, const unsigned char * const input)
 {

--- a/cJSON.c
+++ b/cJSON.c
@@ -194,7 +194,7 @@ typedef struct
 #define buffer_at_offset(buffer) ((buffer)->content + (buffer)->offset)
 
 /* Parse the input text to generate a number, and populate the result into item. */
-static const unsigned char *parse_number(cJSON * const item, parse_buffer * const input_buffer)
+static cJSON_bool parse_number(cJSON * const item, parse_buffer * const input_buffer)
 {
     double number = 0;
     unsigned char *after_end = NULL;
@@ -203,7 +203,7 @@ static const unsigned char *parse_number(cJSON * const item, parse_buffer * cons
 
     if ((input_buffer == NULL) || (input_buffer->content == NULL))
     {
-        return NULL;
+        return false;
     }
 
     /* copy the number into a temporary buffer and zero terminate the string
@@ -243,7 +243,7 @@ static const unsigned char *parse_number(cJSON * const item, parse_buffer * cons
     number = strtod((const char*)number_c_string, (char**)&after_end);
     if (number_c_string == after_end)
     {
-        return NULL; /* parse_error */
+        return false; /* parse_error */
     }
 
     item->valuedouble = number;
@@ -265,7 +265,7 @@ static const unsigned char *parse_number(cJSON * const item, parse_buffer * cons
     item->type = cJSON_Number;
 
     input_buffer->offset += (size_t)(after_end - number_c_string);
-    return buffer_at_offset(input_buffer);
+    return true;
 }
 
 /* don't ask me, but the original cJSON_SetNumberValue returns an integer or double */
@@ -632,7 +632,7 @@ fail:
 }
 
 /* Parse the input text into an unescaped cinput, and populate item. */
-static const unsigned char *parse_string(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
+static cJSON_bool parse_string(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
 {
     const unsigned char *input_pointer = buffer_at_offset(input_buffer) + 1;
     const unsigned char *input_end = buffer_at_offset(input_buffer) + 1;
@@ -746,7 +746,7 @@ static const unsigned char *parse_string(cJSON * const item, parse_buffer * cons
     input_buffer->offset = (size_t) (input_end - input_buffer->content);
     input_buffer->offset++;
 
-    return buffer_at_offset(input_buffer);
+    return true;
 
 fail:
     if (output != NULL)
@@ -754,7 +754,7 @@ fail:
         hooks->deallocate(output);
     }
 
-    return NULL;
+    return false;
 }
 
 /* Render the cstring provided to an escaped version that can be printed. */
@@ -886,11 +886,11 @@ static cJSON_bool print_string(const cJSON * const item, printbuffer * const p, 
 }
 
 /* Predeclare these prototypes. */
-static const unsigned char *parse_value(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
 static cJSON_bool print_value(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
-static const unsigned char *parse_array(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
 static cJSON_bool print_array(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
-static const unsigned char *parse_object(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
 static cJSON_bool print_object(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
 
 /* Utility to jump whitespace and cr/lf */
@@ -950,12 +950,13 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return
     buffer.length = strlen((const char*)value) + sizeof("");
     buffer.offset = 0;
 
-    end = parse_value(item, buffer_skip_whitespace(&buffer), error_pointer, &global_hooks);
-    if (end == NULL)
+    if (!parse_value(item, buffer_skip_whitespace(&buffer), error_pointer, &global_hooks))
     {
         /* parse failure. ep is set. */
         goto fail;
     }
+
+    end = buffer_at_offset(&buffer);
 
     /* if we require null-terminated JSON without appended garbage, skip and then check for a null terminator */
     if (require_null_terminated)
@@ -1095,12 +1096,11 @@ CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buf, const i
 }
 
 /* Parser core - when encountering text, process appropriately. */
-static const unsigned  char *parse_value(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
 {
-    const unsigned char *content_pointer = NULL;
     if ((input_buffer == NULL) || (input_buffer->content == NULL))
     {
-        return NULL; /* no input */
+        return false; /* no input */
     }
 
     /* parse the different types of values */
@@ -1109,14 +1109,14 @@ static const unsigned  char *parse_value(cJSON * const item, parse_buffer * cons
     {
         item->type = cJSON_NULL;
         input_buffer->offset += 4;
-        return buffer_at_offset(input_buffer);
+        return true;
     }
     /* false */
     if (can_read(input_buffer, 5) && (strncmp((const char*)buffer_at_offset(input_buffer), "false", 5) == 0))
     {
         item->type = cJSON_False;
         input_buffer->offset += 5;
-        return buffer_at_offset(input_buffer);
+        return true;
     }
     /* true */
     if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "true", 4) == 0))
@@ -1124,12 +1124,12 @@ static const unsigned  char *parse_value(cJSON * const item, parse_buffer * cons
         item->type = cJSON_True;
         item->valueint = 1;
         input_buffer->offset += 4;
-        return buffer_at_offset(input_buffer);
+        return true;
     }
     /* string */
     if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '\"'))
     {
-        return content_pointer = parse_string(item, input_buffer, error_pointer, hooks);
+        return parse_string(item, input_buffer, error_pointer, hooks);
     }
     /* number */
     if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9'))))
@@ -1144,14 +1144,7 @@ static const unsigned  char *parse_value(cJSON * const item, parse_buffer * cons
     /* object */
     if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '{'))
     {
-        content_pointer = parse_object(item, input_buffer, error_pointer, hooks);
-        if (content_pointer == NULL)
-        {
-            return NULL;
-        }
-
-        input_buffer->offset = (size_t)(content_pointer - input_buffer->content);
-        return buffer_at_offset(input_buffer);
+        return parse_object(item, input_buffer, error_pointer, hooks);
     }
 
     /* failure. */
@@ -1168,7 +1161,7 @@ static const unsigned  char *parse_value(cJSON * const item, parse_buffer * cons
         *error_pointer = input_buffer->content;
     }
 
-    return NULL;
+    return false;
 }
 
 /* Render a value to text. */
@@ -1250,7 +1243,7 @@ static cJSON_bool print_value(const cJSON * const item, const size_t depth, cons
 }
 
 /* Build an array from input text. */
-static const unsigned char *parse_array(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
 {
     cJSON *head = NULL; /* head of the linked list */
     cJSON *current_item = NULL;
@@ -1307,7 +1300,7 @@ static const unsigned char *parse_array(cJSON * const item, parse_buffer * const
         /* parse next value */
         input_buffer->offset++;
         buffer_skip_whitespace(input_buffer);
-        if (parse_value(current_item, input_buffer, error_pointer, hooks) == NULL)
+        if (!parse_value(current_item, input_buffer, error_pointer, hooks))
         {
             goto fail; /* failed to parse value */
         }
@@ -1327,7 +1320,7 @@ success:
 
     input_buffer->offset++;
 
-    return buffer_at_offset(input_buffer);
+    return true;
 
 fail:
     if (head != NULL)
@@ -1335,7 +1328,7 @@ fail:
         cJSON_Delete(head);
     }
 
-    return NULL;
+    return false;
 }
 
 /* Render an array to text */
@@ -1399,7 +1392,7 @@ static cJSON_bool print_array(const cJSON * const item, const size_t depth, cons
 }
 
 /* Build an object from the text. */
-static const unsigned char *parse_object(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
 {
     cJSON *head = NULL; /* linked list head */
     cJSON *current_item = NULL;
@@ -1454,7 +1447,7 @@ static const unsigned char *parse_object(cJSON * const item, parse_buffer * cons
         /* parse the name of the child */
         input_buffer->offset++;
         buffer_skip_whitespace(input_buffer);
-        if (parse_string(current_item, input_buffer, error_pointer, hooks) == NULL)
+        if (!parse_string(current_item, input_buffer, error_pointer, hooks))
         {
             goto fail; /* faile to parse name */
         }
@@ -1473,7 +1466,7 @@ static const unsigned char *parse_object(cJSON * const item, parse_buffer * cons
         /* parse the value */
         input_buffer->offset++;
         buffer_skip_whitespace(input_buffer);
-        if (parse_value(current_item, input_buffer, error_pointer, hooks) == NULL)
+        if (!parse_value(current_item, input_buffer, error_pointer, hooks))
         {
             goto fail; /* failed to parse value */
         }
@@ -1492,7 +1485,7 @@ success:
     item->child = head;
 
     input_buffer->offset++;
-    return buffer_at_offset(input_buffer);
+    return true;
 
 fail:
     if (head != NULL)
@@ -1500,7 +1493,7 @@ fail:
         cJSON_Delete(head);
     }
 
-    return NULL;
+    return false;
 }
 
 /* Render an object to text. */

--- a/cJSON.c
+++ b/cJSON.c
@@ -835,7 +835,7 @@ static const unsigned char *parse_value(cJSON * const item, parse_buffer * const
 static cJSON_bool print_value(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
 static const unsigned char *parse_array(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
 static cJSON_bool print_array(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
-static const unsigned char *parse_object(cJSON * const item, const unsigned char *input, const unsigned char ** const ep, const internal_hooks * const hooks);
+static const unsigned char *parse_object(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
 static cJSON_bool print_object(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
 
 /* Utility to jump whitespace and cr/lf */
@@ -1103,7 +1103,7 @@ static const unsigned  char *parse_value(cJSON * const item, parse_buffer * cons
     /* object */
     if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '{'))
     {
-        content_pointer = parse_object(item, buffer_at_offset(input_buffer), error_pointer, hooks);
+        content_pointer = parse_object(item, input_buffer, error_pointer, hooks);
         if (content_pointer == NULL)
         {
             return NULL;
@@ -1358,26 +1358,35 @@ static cJSON_bool print_array(const cJSON * const item, const size_t depth, cons
 }
 
 /* Build an object from the text. */
-static const unsigned char *parse_object(cJSON * const item, const unsigned char *input, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
+static const unsigned char *parse_object(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
 {
     cJSON *head = NULL; /* linked list head */
     cJSON *current_item = NULL;
-    parse_buffer input_buffer;
+    const unsigned char *content_pointer = NULL;
 
-    if (*input != '{')
+    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '{'))
     {
-        *error_pointer = input;
+        *error_pointer = buffer_at_offset(input_buffer);
         goto fail; /* not an object */
     }
 
-    input = skip_whitespace(input + 1);
-    if (*input == '}')
+    input_buffer->offset++;
+    buffer_skip_whitespace(input_buffer);
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '}'))
     {
         goto success; /* empty object */
     }
 
+    /* check if we skipped to the end of the buffer */
+    if (cannot_access_at_index(input_buffer, 0))
+    {
+        input_buffer->offset--;
+        *error_pointer = buffer_at_offset(input_buffer);
+        goto fail;
+    }
+
     /* step back to character in front of the first element */
-    input--;
+    input_buffer->offset--;
     /* loop through the comma separated array elements */
     do
     {
@@ -1403,41 +1412,40 @@ static const unsigned char *parse_object(cJSON * const item, const unsigned char
         }
 
         /* parse the name of the child */
-        input = skip_whitespace(input + 1);
-        input = parse_string(current_item, input, error_pointer, hooks);
-        input = skip_whitespace(input);
-        if (input == NULL)
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        content_pointer = parse_string(current_item, buffer_at_offset(input_buffer), error_pointer, hooks);
+        if (content_pointer == NULL)
         {
             goto fail; /* faile to parse name */
         }
+        input_buffer->offset = (size_t)(content_pointer - input_buffer->content);
+        buffer_skip_whitespace(input_buffer);
 
         /* swap valuestring and string, because we parsed the name */
         current_item->string = current_item->valuestring;
         current_item->valuestring = NULL;
 
-        if (*input != ':')
+        if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != ':'))
         {
-            *error_pointer = input;
+            *error_pointer = buffer_at_offset(input_buffer);
             goto fail; /* invalid object */
         }
 
         /* parse the value */
-        input = skip_whitespace(input + 1);
-        input_buffer.content = (const unsigned char*)input;
-        input_buffer.offset = 0;
-        input_buffer.length = strlen((const char*)input) + sizeof("");
-        input = parse_value(current_item, &input_buffer, error_pointer, hooks);
-        input = skip_whitespace(input);
-        if (input == NULL)
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (parse_value(current_item, input_buffer, error_pointer, hooks) == NULL)
         {
             goto fail; /* failed to parse value */
         }
+        buffer_skip_whitespace(input_buffer);
     }
-    while (*input == ',');
+    while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
 
-    if (*input != '}')
+    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '}'))
     {
-        *error_pointer = input;
+        *error_pointer = buffer_at_offset(input_buffer);
         goto fail; /* expected end of object */
     }
 
@@ -1445,7 +1453,8 @@ success:
     item->type = cJSON_Object;
     item->child = head;
 
-    return input + 1;
+    input_buffer->offset++;
+    return buffer_at_offset(input_buffer);
 
 fail:
     if (head != NULL)

--- a/cJSON.c
+++ b/cJSON.c
@@ -505,7 +505,7 @@ static unsigned parse_hex4(const unsigned char * const input)
 
 /* converts a UTF-16 literal to UTF-8
  * A literal can be one or two sequences of the form \uXXXX */
-static unsigned char utf16_literal_to_utf8(const unsigned char * const input_pointer, const unsigned char * const input_end, unsigned char **output_pointer, const unsigned char **error_pointer)
+static unsigned char utf16_literal_to_utf8(const unsigned char * const input_pointer, const unsigned char * const input_end, unsigned char **output_pointer)
 {
     long unsigned int codepoint = 0;
     unsigned int first_code = 0;
@@ -518,7 +518,6 @@ static unsigned char utf16_literal_to_utf8(const unsigned char * const input_poi
     if ((input_end - first_sequence) < 6)
     {
         /* input ends unexpectedly */
-        *error_pointer = first_sequence;
         goto fail;
     }
 
@@ -528,7 +527,6 @@ static unsigned char utf16_literal_to_utf8(const unsigned char * const input_poi
     /* check that the code is valid */
     if (((first_code >= 0xDC00) && (first_code <= 0xDFFF)))
     {
-        *error_pointer = first_sequence;
         goto fail;
     }
 
@@ -542,14 +540,12 @@ static unsigned char utf16_literal_to_utf8(const unsigned char * const input_poi
         if ((input_end - second_sequence) < 6)
         {
             /* input ends unexpectedly */
-            *error_pointer = first_sequence;
             goto fail;
         }
 
         if ((second_sequence[0] != '\\') || (second_sequence[1] != 'u'))
         {
             /* missing second half of the surrogate pair */
-            *error_pointer = first_sequence;
             goto fail;
         }
 
@@ -559,7 +555,6 @@ static unsigned char utf16_literal_to_utf8(const unsigned char * const input_poi
         if ((second_code < 0xDC00) || (second_code > 0xDFFF))
         {
             /* invalid second half of the surrogate pair */
-            *error_pointer = first_sequence;
             goto fail;
         }
 
@@ -602,7 +597,6 @@ static unsigned char utf16_literal_to_utf8(const unsigned char * const input_poi
     else
     {
         /* invalid unicode codepoint */
-        *error_pointer = first_sequence;
         goto fail;
     }
 
@@ -632,7 +626,7 @@ fail:
 }
 
 /* Parse the input text into an unescaped cinput, and populate item. */
-static cJSON_bool parse_string(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
+static cJSON_bool parse_string(cJSON * const item, parse_buffer * const input_buffer, const internal_hooks * const hooks)
 {
     const unsigned char *input_pointer = buffer_at_offset(input_buffer) + 1;
     const unsigned char *input_end = buffer_at_offset(input_buffer) + 1;
@@ -642,7 +636,6 @@ static cJSON_bool parse_string(cJSON * const item, parse_buffer * const input_bu
     /* not a string */
     if (buffer_at_offset(input_buffer)[0] != '\"')
     {
-        *error_pointer = buffer_at_offset(input_buffer);
         goto fail;
     }
 
@@ -721,7 +714,7 @@ static cJSON_bool parse_string(cJSON * const item, parse_buffer * const input_bu
 
                 /* UTF-16 literal */
                 case 'u':
-                    sequence_length = utf16_literal_to_utf8(input_pointer, input_end, &output_pointer, error_pointer);
+                    sequence_length = utf16_literal_to_utf8(input_pointer, input_end, &output_pointer);
                     if (sequence_length == 0)
                     {
                         /* failed to convert UTF16-literal to UTF-8 */
@@ -730,7 +723,6 @@ static cJSON_bool parse_string(cJSON * const item, parse_buffer * const input_bu
                     break;
 
                 default:
-                    *error_pointer = input_pointer;
                     goto fail;
             }
             input_pointer += sequence_length;
@@ -752,6 +744,11 @@ fail:
     if (output != NULL)
     {
         hooks->deallocate(output);
+    }
+
+    if (input_pointer != NULL)
+    {
+        input_buffer->offset = (size_t)(input_pointer - input_buffer->content);
     }
 
     return false;
@@ -886,11 +883,11 @@ static cJSON_bool print_string(const cJSON * const item, printbuffer * const p, 
 }
 
 /* Predeclare these prototypes. */
-static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer, const internal_hooks * const hooks);
 static cJSON_bool print_value(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
-static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer, const internal_hooks * const hooks);
 static cJSON_bool print_array(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
-static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer, const internal_hooks * const hooks);
 static cJSON_bool print_object(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
 
 /* Utility to jump whitespace and cr/lf */
@@ -921,14 +918,7 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return
     /* use global error pointer if no specific one was given */
     const unsigned char **error_pointer = (return_parse_end != NULL) ? (const unsigned char**)return_parse_end : &global_ep;
     cJSON *item = NULL;
-
     *error_pointer = NULL;
-
-    item = cJSON_New_Item(&global_hooks);
-    if (item == NULL) /* memory fail */
-    {
-        goto fail;
-    }
 
     if (value == NULL)
     {
@@ -939,7 +929,13 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return
     buffer.length = strlen((const char*)value) + sizeof("");
     buffer.offset = 0;
 
-    if (!parse_value(item, buffer_skip_whitespace(&buffer), error_pointer, &global_hooks))
+    item = cJSON_New_Item(&global_hooks);
+    if (item == NULL) /* memory fail */
+    {
+        goto fail;
+    }
+
+    if (!parse_value(item, buffer_skip_whitespace(&buffer), &global_hooks))
     {
         /* parse failure. ep is set. */
         goto fail;
@@ -951,7 +947,6 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return
         buffer_skip_whitespace(&buffer);
         if ((buffer.offset >= buffer.length) || buffer_at_offset(&buffer)[0] != '\0')
         {
-            *error_pointer = buffer_at_offset(&buffer);
             goto fail;
         }
     }
@@ -966,6 +961,18 @@ fail:
     if (item != NULL)
     {
         cJSON_Delete(item);
+    }
+
+    if (value != NULL)
+    {
+        if (buffer.offset < buffer.length)
+        {
+            *error_pointer = buffer_at_offset(&buffer);
+        }
+        else if (buffer.length > 0)
+        {
+            *error_pointer = buffer.content + buffer.length - 1;
+        }
     }
 
     return NULL;
@@ -1083,7 +1090,7 @@ CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buf, const i
 }
 
 /* Parser core - when encountering text, process appropriately. */
-static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer, const internal_hooks * const hooks)
 {
     if ((input_buffer == NULL) || (input_buffer->content == NULL))
     {
@@ -1116,7 +1123,7 @@ static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buf
     /* string */
     if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '\"'))
     {
-        return parse_string(item, input_buffer, error_pointer, hooks);
+        return parse_string(item, input_buffer, hooks);
     }
     /* number */
     if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9'))))
@@ -1126,27 +1133,14 @@ static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buf
     /* array */
     if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '['))
     {
-        return parse_array(item, input_buffer, error_pointer, hooks);
+        return parse_array(item, input_buffer, hooks);
     }
     /* object */
     if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '{'))
     {
-        return parse_object(item, input_buffer, error_pointer, hooks);
+        return parse_object(item, input_buffer, hooks);
     }
 
-    /* failure. */
-    if (can_access_at_index(input_buffer, 0))
-    {
-        *error_pointer = buffer_at_offset(input_buffer);
-    }
-    else if (input_buffer->length > 0)
-    {
-        *error_pointer = input_buffer->content + input_buffer->length - 1;
-    }
-    else
-    {
-        *error_pointer = input_buffer->content;
-    }
 
     return false;
 }
@@ -1230,7 +1224,7 @@ static cJSON_bool print_value(const cJSON * const item, const size_t depth, cons
 }
 
 /* Build an array from input text. */
-static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer, const internal_hooks * const hooks)
 {
     cJSON *head = NULL; /* head of the linked list */
     cJSON *current_item = NULL;
@@ -1238,7 +1232,6 @@ static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buf
     if (buffer_at_offset(input_buffer)[0] != '[')
     {
         /* not an array */
-        *error_pointer = buffer_at_offset(input_buffer);
         goto fail;
     }
 
@@ -1254,7 +1247,6 @@ static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buf
     if (cannot_access_at_index(input_buffer, 0))
     {
         input_buffer->offset--;
-        *error_pointer = buffer_at_offset(input_buffer);
         goto fail;
     }
 
@@ -1287,7 +1279,7 @@ static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buf
         /* parse next value */
         input_buffer->offset++;
         buffer_skip_whitespace(input_buffer);
-        if (!parse_value(current_item, input_buffer, error_pointer, hooks))
+        if (!parse_value(current_item, input_buffer, hooks))
         {
             goto fail; /* failed to parse value */
         }
@@ -1297,7 +1289,6 @@ static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buf
 
     if (cannot_access_at_index(input_buffer, 0) || buffer_at_offset(input_buffer)[0] != ']')
     {
-        *error_pointer = buffer_at_offset(input_buffer);
         goto fail; /* expected end of array */
     }
 
@@ -1379,14 +1370,13 @@ static cJSON_bool print_array(const cJSON * const item, const size_t depth, cons
 }
 
 /* Build an object from the text. */
-static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer, const internal_hooks * const hooks)
 {
     cJSON *head = NULL; /* linked list head */
     cJSON *current_item = NULL;
 
     if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '{'))
     {
-        *error_pointer = buffer_at_offset(input_buffer);
         goto fail; /* not an object */
     }
 
@@ -1401,7 +1391,6 @@ static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_bu
     if (cannot_access_at_index(input_buffer, 0))
     {
         input_buffer->offset--;
-        *error_pointer = buffer_at_offset(input_buffer);
         goto fail;
     }
 
@@ -1434,7 +1423,7 @@ static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_bu
         /* parse the name of the child */
         input_buffer->offset++;
         buffer_skip_whitespace(input_buffer);
-        if (!parse_string(current_item, input_buffer, error_pointer, hooks))
+        if (!parse_string(current_item, input_buffer, hooks))
         {
             goto fail; /* faile to parse name */
         }
@@ -1446,14 +1435,13 @@ static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_bu
 
         if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != ':'))
         {
-            *error_pointer = buffer_at_offset(input_buffer);
             goto fail; /* invalid object */
         }
 
         /* parse the value */
         input_buffer->offset++;
         buffer_skip_whitespace(input_buffer);
-        if (!parse_value(current_item, input_buffer, error_pointer, hooks))
+        if (!parse_value(current_item, input_buffer, hooks))
         {
             goto fail; /* failed to parse value */
         }
@@ -1463,7 +1451,6 @@ static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_bu
 
     if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '}'))
     {
-        *error_pointer = buffer_at_offset(input_buffer);
         goto fail; /* expected end of object */
     }
 

--- a/cJSON.c
+++ b/cJSON.c
@@ -211,13 +211,32 @@ static const unsigned char *parse_number(cJSON * const item, parse_buffer * cons
      * and strtod only works with zero terminated strings */
     for (i = 0; (i < (sizeof(number_c_string) - 1)) && can_access_at_index(input_buffer, i); i++)
     {
-        if (strchr("0123456789+-eE.", buffer_at_offset(input_buffer)[i]) == NULL)
+        switch (buffer_at_offset(input_buffer)[i])
         {
-            break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            case '+':
+            case '-':
+            case 'e':
+            case 'E':
+            case '.':
+                break;
+
+            default:
+                goto loop_end;
         }
 
         number_c_string[i] = buffer_at_offset(input_buffer)[i];
     }
+    loop_end:
     number_c_string[i] = '\0';
 
 
@@ -769,15 +788,25 @@ static cJSON_bool print_string_ptr(const unsigned char * const input, printbuffe
     /* set "flag" to 1 if something needs to be escaped */
     for (input_pointer = input; *input_pointer; input_pointer++)
     {
-        if (strchr("\"\\\b\f\n\r\t", *input_pointer))
+        switch (*input_pointer)
         {
-            /* one character escape sequence */
-            escape_characters++;
-        }
-        else if (*input_pointer < 32)
-        {
-            /* UTF-16 escape sequence uXXXX */
-            escape_characters += 5;
+            case '\"':
+            case '\\':
+            case '\b':
+            case '\f':
+            case '\n':
+            case '\r':
+            case '\t':
+                /* one character escape sequence */
+                escape_characters++;
+                break;
+            default:
+                if (*input_pointer < 32)
+                {
+                    /* UTF-16 escape sequence uXXXX */
+                    escape_characters += 5;
+                }
+                break;
         }
     }
     output_length = (size_t)(input_pointer - input) + escape_characters;

--- a/cJSON.c
+++ b/cJSON.c
@@ -894,16 +894,6 @@ static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_bu
 static cJSON_bool print_object(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
 
 /* Utility to jump whitespace and cr/lf */
-static const unsigned char *skip_whitespace(const unsigned char *in)
-{
-    while (in && *in && (*in <= 32))
-    {
-        in++;
-    }
-
-    return in;
-}
-
 static parse_buffer *buffer_skip_whitespace(parse_buffer * const buffer)
 {
     if ((buffer == NULL) || (buffer->content == NULL))
@@ -928,7 +918,6 @@ static parse_buffer *buffer_skip_whitespace(parse_buffer * const buffer)
 CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated)
 {
     parse_buffer buffer;
-    const unsigned char *end = NULL;
     /* use global error pointer if no specific one was given */
     const unsigned char **error_pointer = (return_parse_end != NULL) ? (const unsigned char**)return_parse_end : &global_ep;
     cJSON *item = NULL;
@@ -956,21 +945,19 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return
         goto fail;
     }
 
-    end = buffer_at_offset(&buffer);
-
     /* if we require null-terminated JSON without appended garbage, skip and then check for a null terminator */
     if (require_null_terminated)
     {
-        end = skip_whitespace(end);
-        if (*end != '\0')
+        buffer_skip_whitespace(&buffer);
+        if ((buffer.offset >= buffer.length) || buffer_at_offset(&buffer)[0] != '\0')
         {
-            *error_pointer = end;
+            *error_pointer = buffer_at_offset(&buffer);
             goto fail;
         }
     }
     if (return_parse_end)
     {
-        *return_parse_end = (const char*)end;
+        *return_parse_end = (const char*)buffer_at_offset(&buffer);
     }
 
     return item;

--- a/cJSON.c
+++ b/cJSON.c
@@ -526,7 +526,7 @@ static unsigned char utf16_literal_to_utf8(const unsigned char * const input_poi
     first_code = parse_hex4(first_sequence + 2);
 
     /* check that the code is valid */
-    if (((first_code >= 0xDC00) && (first_code <= 0xDFFF)) || (first_code == 0))
+    if (((first_code >= 0xDC00) && (first_code <= 0xDFFF)))
     {
         *error_pointer = first_sequence;
         goto fail;

--- a/cJSON.c
+++ b/cJSON.c
@@ -831,7 +831,7 @@ static cJSON_bool print_string(const cJSON * const item, printbuffer * const p, 
 }
 
 /* Predeclare these prototypes. */
-static const unsigned char *parse_value(cJSON * const item, const unsigned char * const input, const unsigned char ** const ep, const internal_hooks * const hooks);
+static const unsigned char *parse_value(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
 static cJSON_bool print_value(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
 static const unsigned char *parse_array(cJSON * const item, const unsigned char *input, const unsigned char ** const ep, const internal_hooks * const hooks);
 static cJSON_bool print_array(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
@@ -849,9 +849,25 @@ static const unsigned char *skip_whitespace(const unsigned char *in)
     return in;
 }
 
+static parse_buffer *buffer_skip_whitespace(parse_buffer * const buffer)
+{
+    const unsigned char *skipped_pointer = NULL;
+
+    if ((buffer == NULL) || (buffer->content == NULL))
+    {
+        return NULL;
+    }
+
+    skipped_pointer = skip_whitespace(buffer_at_offset(buffer));
+    buffer->offset = (size_t)(skipped_pointer - buffer->content);
+
+    return buffer;
+}
+
 /* Parse an object - create a new root, and populate. */
 CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated)
 {
+    parse_buffer buffer;
     const unsigned char *end = NULL;
     /* use global error pointer if no specific one was given */
     const unsigned char **error_pointer = (return_parse_end != NULL) ? (const unsigned char**)return_parse_end : &global_ep;
@@ -870,7 +886,11 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return
         goto fail;
     }
 
-    end = parse_value(item, skip_whitespace((const unsigned char*)value), error_pointer, &global_hooks);
+    buffer.content = (const unsigned char*)value;
+    buffer.length = strlen((const char*)value) + sizeof("");
+    buffer.offset = 0;
+
+    end = parse_value(item, buffer_skip_whitespace(&buffer), error_pointer, &global_hooks);
     if (end == NULL)
     {
         /* parse failure. ep is set. */
@@ -1015,56 +1035,71 @@ CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buf, const i
 }
 
 /* Parser core - when encountering text, process appropriately. */
-static const unsigned  char *parse_value(cJSON * const item, const unsigned char * const input, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
+static const unsigned  char *parse_value(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
 {
-    if (input == NULL)
+    if ((input_buffer == NULL) || (input_buffer->content == NULL))
     {
         return NULL; /* no input */
     }
 
     /* parse the different types of values */
     /* null */
-    if (!strncmp((const char*)input, "null", 4))
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "null", 4) == 0))
     {
         item->type = cJSON_NULL;
-        return input + 4;
+        input_buffer->offset += 4;
+        return buffer_at_offset(input_buffer);
     }
     /* false */
-    if (!strncmp((const char*)input, "false", 5))
+    if (can_read(input_buffer, 5) && (strncmp((const char*)buffer_at_offset(input_buffer), "false", 5) == 0))
     {
         item->type = cJSON_False;
-        return input + 5;
+        input_buffer->offset += 5;
+        return buffer_at_offset(input_buffer);
     }
     /* true */
-    if (!strncmp((const char*)input, "true", 4))
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "true", 4) == 0))
     {
         item->type = cJSON_True;
         item->valueint = 1;
-        return input + 4;
+        input_buffer->offset += 4;
+        return buffer_at_offset(input_buffer);
     }
     /* string */
-    if (*input == '\"')
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '\"'))
     {
-        return parse_string(item, input, error_pointer, hooks);
+        return parse_string(item, buffer_at_offset(input_buffer), error_pointer, hooks);
     }
     /* number */
-    if ((*input == '-') || ((*input >= '0') && (*input <= '9')))
+    if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9'))))
     {
-        return parse_number(item, input);
+        return parse_number(item, buffer_at_offset(input_buffer));
     }
     /* array */
-    if (*input == '[')
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '['))
     {
-        return parse_array(item, input, error_pointer, hooks);
+        return parse_array(item, buffer_at_offset(input_buffer), error_pointer, hooks);
     }
     /* object */
-    if (*input == '{')
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '{'))
     {
-        return parse_object(item, input, error_pointer, hooks);
+        return parse_object(item, buffer_at_offset(input_buffer), error_pointer, hooks);
     }
 
     /* failure. */
-    *error_pointer = input;
+    if (can_access_at_index(input_buffer, 0))
+    {
+        *error_pointer = buffer_at_offset(input_buffer);
+    }
+    else if (input_buffer->length > 0)
+    {
+        *error_pointer = input_buffer->content + input_buffer->length - 1;
+    }
+    else
+    {
+        *error_pointer = input_buffer->content;
+    }
+
     return NULL;
 }
 
@@ -1151,6 +1186,7 @@ static const unsigned char *parse_array(cJSON * const item, const unsigned char 
 {
     cJSON *head = NULL; /* head of the linked list */
     cJSON *current_item = NULL;
+    parse_buffer input_buffer;
 
     if (*input != '[')
     {
@@ -1194,7 +1230,10 @@ static const unsigned char *parse_array(cJSON * const item, const unsigned char 
 
         /* parse next value */
         input = skip_whitespace(input + 1);
-        input = parse_value(current_item, input, error_pointer, hooks);
+        input_buffer.content = (const unsigned char*)input;
+        input_buffer.offset = 0;
+        input_buffer.length = strlen((const char*)input) + sizeof("");
+        input = parse_value(current_item, &input_buffer, error_pointer, hooks);
         input = skip_whitespace(input);
         if (input == NULL)
         {
@@ -1289,6 +1328,7 @@ static const unsigned char *parse_object(cJSON * const item, const unsigned char
 {
     cJSON *head = NULL; /* linked list head */
     cJSON *current_item = NULL;
+    parse_buffer input_buffer;
 
     if (*input != '{')
     {
@@ -1349,7 +1389,10 @@ static const unsigned char *parse_object(cJSON * const item, const unsigned char
 
         /* parse the value */
         input = skip_whitespace(input + 1);
-        input = parse_value(current_item, input, error_pointer, hooks);
+        input_buffer.content = (const unsigned char*)input;
+        input_buffer.offset = 0;
+        input_buffer.length = strlen((const char*)input) + sizeof("");
+        input = parse_value(current_item, &input_buffer, error_pointer, hooks);
         input = skip_whitespace(input);
         if (input == NULL)
         {

--- a/cJSON.c
+++ b/cJSON.c
@@ -833,7 +833,7 @@ static cJSON_bool print_string(const cJSON * const item, printbuffer * const p, 
 /* Predeclare these prototypes. */
 static const unsigned char *parse_value(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
 static cJSON_bool print_value(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
-static const unsigned char *parse_array(cJSON * const item, const unsigned char *input, const unsigned char ** const ep, const internal_hooks * const hooks);
+static const unsigned char *parse_array(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const ep, const internal_hooks * const hooks);
 static cJSON_bool print_array(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
 static const unsigned char *parse_object(cJSON * const item, const unsigned char *input, const unsigned char ** const ep, const internal_hooks * const hooks);
 static cJSON_bool print_object(const cJSON * const item, const size_t depth, const cJSON_bool format, printbuffer * const output_buffer, const internal_hooks * const hooks);
@@ -851,15 +851,20 @@ static const unsigned char *skip_whitespace(const unsigned char *in)
 
 static parse_buffer *buffer_skip_whitespace(parse_buffer * const buffer)
 {
-    const unsigned char *skipped_pointer = NULL;
-
     if ((buffer == NULL) || (buffer->content == NULL))
     {
         return NULL;
     }
 
-    skipped_pointer = skip_whitespace(buffer_at_offset(buffer));
-    buffer->offset = (size_t)(skipped_pointer - buffer->content);
+    while (can_access_at_index(buffer, 0) && (buffer_at_offset(buffer)[0] <= 32))
+    {
+       buffer->offset++;
+    }
+
+    if (buffer->offset == buffer->length)
+    {
+        buffer->offset--;
+    }
 
     return buffer;
 }
@@ -1037,6 +1042,7 @@ CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buf, const i
 /* Parser core - when encountering text, process appropriately. */
 static const unsigned  char *parse_value(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
 {
+    const unsigned char *content_pointer = NULL;
     if ((input_buffer == NULL) || (input_buffer->content == NULL))
     {
         return NULL; /* no input */
@@ -1068,22 +1074,43 @@ static const unsigned  char *parse_value(cJSON * const item, parse_buffer * cons
     /* string */
     if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '\"'))
     {
-        return parse_string(item, buffer_at_offset(input_buffer), error_pointer, hooks);
+        content_pointer = parse_string(item, buffer_at_offset(input_buffer), error_pointer, hooks);
+        if (content_pointer == NULL)
+        {
+            return NULL;
+        }
+
+        input_buffer->offset = (size_t)(content_pointer - input_buffer->content);
+        return buffer_at_offset(input_buffer);
     }
     /* number */
     if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9'))))
     {
-        return parse_number(item, buffer_at_offset(input_buffer));
+        content_pointer = parse_number(item, buffer_at_offset(input_buffer));
+        if (content_pointer == NULL)
+        {
+            return NULL;
+        }
+
+        input_buffer->offset = (size_t)(content_pointer - input_buffer->content);
+        return buffer_at_offset(input_buffer);
     }
     /* array */
     if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '['))
     {
-        return parse_array(item, buffer_at_offset(input_buffer), error_pointer, hooks);
+        return parse_array(item, input_buffer, error_pointer, hooks);
     }
     /* object */
     if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '{'))
     {
-        return parse_object(item, buffer_at_offset(input_buffer), error_pointer, hooks);
+        content_pointer = parse_object(item, buffer_at_offset(input_buffer), error_pointer, hooks);
+        if (content_pointer == NULL)
+        {
+            return NULL;
+        }
+
+        input_buffer->offset = (size_t)(content_pointer - input_buffer->content);
+        return buffer_at_offset(input_buffer);
     }
 
     /* failure. */
@@ -1182,28 +1209,36 @@ static cJSON_bool print_value(const cJSON * const item, const size_t depth, cons
 }
 
 /* Build an array from input text. */
-static const unsigned char *parse_array(cJSON * const item, const unsigned char *input, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
+static const unsigned char *parse_array(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
 {
     cJSON *head = NULL; /* head of the linked list */
     cJSON *current_item = NULL;
-    parse_buffer input_buffer;
 
-    if (*input != '[')
+    if (buffer_at_offset(input_buffer)[0] != '[')
     {
         /* not an array */
-        *error_pointer = input;
+        *error_pointer = buffer_at_offset(input_buffer);
         goto fail;
     }
 
-    input = skip_whitespace(input + 1);
-    if (*input == ']')
+    input_buffer->offset++;
+    buffer_skip_whitespace(input_buffer);
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ']'))
     {
         /* empty array */
         goto success;
     }
 
+    /* check if we skipped to the end of the buffer */
+    if (cannot_access_at_index(input_buffer, 0))
+    {
+        input_buffer->offset--;
+        *error_pointer = buffer_at_offset(input_buffer);
+        goto fail;
+    }
+
     /* step back to character in front of the first element */
-    input--;
+    input_buffer->offset--;
     /* loop through the comma separated array elements */
     do
     {
@@ -1229,22 +1264,19 @@ static const unsigned char *parse_array(cJSON * const item, const unsigned char 
         }
 
         /* parse next value */
-        input = skip_whitespace(input + 1);
-        input_buffer.content = (const unsigned char*)input;
-        input_buffer.offset = 0;
-        input_buffer.length = strlen((const char*)input) + sizeof("");
-        input = parse_value(current_item, &input_buffer, error_pointer, hooks);
-        input = skip_whitespace(input);
-        if (input == NULL)
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (parse_value(current_item, input_buffer, error_pointer, hooks) == NULL)
         {
             goto fail; /* failed to parse value */
         }
+        buffer_skip_whitespace(input_buffer);
     }
-    while (*input == ',');
+    while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
 
-    if (*input != ']')
+    if (cannot_access_at_index(input_buffer, 0) || buffer_at_offset(input_buffer)[0] != ']')
     {
-        *error_pointer = input;
+        *error_pointer = buffer_at_offset(input_buffer);
         goto fail; /* expected end of array */
     }
 
@@ -1252,7 +1284,9 @@ success:
     item->type = cJSON_Array;
     item->child = head;
 
-    return input + 1;
+    input_buffer->offset++;
+
+    return buffer_at_offset(input_buffer);
 
 fail:
     if (head != NULL)

--- a/cJSON.c
+++ b/cJSON.c
@@ -613,17 +613,17 @@ fail:
 }
 
 /* Parse the input text into an unescaped cinput, and populate item. */
-static const unsigned char *parse_string(cJSON * const item, const unsigned char * const input, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
+static const unsigned char *parse_string(cJSON * const item, parse_buffer * const input_buffer, const unsigned char ** const error_pointer, const internal_hooks * const hooks)
 {
-    const unsigned char *input_pointer = input + 1;
-    const unsigned char *input_end = input + 1;
+    const unsigned char *input_pointer = buffer_at_offset(input_buffer) + 1;
+    const unsigned char *input_end = buffer_at_offset(input_buffer) + 1;
     unsigned char *output_pointer = NULL;
     unsigned char *output = NULL;
 
     /* not a string */
-    if (*input != '\"')
+    if (buffer_at_offset(input_buffer)[0] != '\"')
     {
-        *error_pointer = input;
+        *error_pointer = buffer_at_offset(input_buffer);
         goto fail;
     }
 
@@ -631,12 +631,12 @@ static const unsigned char *parse_string(cJSON * const item, const unsigned char
         /* calculate approximate size of the output (overestimate) */
         size_t allocation_length = 0;
         size_t skipped_bytes = 0;
-        while ((*input_end != '\"') && (*input_end != '\0'))
+        while ((*input_end != '\"') && ((size_t)(input_end - input_buffer->content) < input_buffer->length))
         {
             /* is escape sequence */
             if (input_end[0] == '\\')
             {
-                if (input_end[1] == '\0')
+                if ((size_t)(input_end + 1 - input_buffer->content) >= input_buffer->length)
                 {
                     /* prevent buffer overflow when last input character is a backslash */
                     goto fail;
@@ -646,13 +646,13 @@ static const unsigned char *parse_string(cJSON * const item, const unsigned char
             }
             input_end++;
         }
-        if (*input_end == '\0')
+        if (*input_end != '\"')
         {
             goto fail; /* string ended unexpectedly */
         }
 
         /* This is at most how much we need for the output */
-        allocation_length = (size_t) (input_end - input) - skipped_bytes;
+        allocation_length = (size_t) (input_end - buffer_at_offset(input_buffer)) - skipped_bytes;
         output = (unsigned char*)hooks->allocate(allocation_length + sizeof(""));
         if (output == NULL)
         {
@@ -672,6 +672,11 @@ static const unsigned char *parse_string(cJSON * const item, const unsigned char
         else
         {
             unsigned char sequence_length = 2;
+            if ((input_end - input_pointer) < 1)
+            {
+                goto fail;
+            }
+
             switch (input_pointer[1])
             {
                 case 'b':
@@ -719,7 +724,10 @@ static const unsigned char *parse_string(cJSON * const item, const unsigned char
     item->type = cJSON_String;
     item->valuestring = (char*)output;
 
-    return input_end + 1;
+    input_buffer->offset = (size_t) (input_end - input_buffer->content);
+    input_buffer->offset++;
+
+    return buffer_at_offset(input_buffer);
 
 fail:
     if (output != NULL)
@@ -1092,14 +1100,7 @@ static const unsigned  char *parse_value(cJSON * const item, parse_buffer * cons
     /* string */
     if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '\"'))
     {
-        content_pointer = parse_string(item, buffer_at_offset(input_buffer), error_pointer, hooks);
-        if (content_pointer == NULL)
-        {
-            return NULL;
-        }
-
-        input_buffer->offset = (size_t)(content_pointer - input_buffer->content);
-        return buffer_at_offset(input_buffer);
+        return content_pointer = parse_string(item, input_buffer, error_pointer, hooks);
     }
     /* number */
     if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9'))))
@@ -1373,7 +1374,6 @@ static const unsigned char *parse_object(cJSON * const item, parse_buffer * cons
 {
     cJSON *head = NULL; /* linked list head */
     cJSON *current_item = NULL;
-    const unsigned char *content_pointer = NULL;
 
     if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '{'))
     {
@@ -1425,12 +1425,10 @@ static const unsigned char *parse_object(cJSON * const item, parse_buffer * cons
         /* parse the name of the child */
         input_buffer->offset++;
         buffer_skip_whitespace(input_buffer);
-        content_pointer = parse_string(current_item, buffer_at_offset(input_buffer), error_pointer, hooks);
-        if (content_pointer == NULL)
+        if (parse_string(current_item, input_buffer, error_pointer, hooks) == NULL)
         {
             goto fail; /* faile to parse name */
         }
-        input_buffer->offset = (size_t)(content_pointer - input_buffer->content);
         buffer_skip_whitespace(input_buffer);
 
         /* swap valuestring and string, because we parsed the name */

--- a/cJSON.c
+++ b/cJSON.c
@@ -194,18 +194,35 @@ typedef struct
 #define buffer_at_offset(buffer) ((buffer)->content + (buffer)->offset)
 
 /* Parse the input text to generate a number, and populate the result into item. */
-static const unsigned char *parse_number(cJSON * const item, const unsigned char * const input)
+static const unsigned char *parse_number(cJSON * const item, parse_buffer * const input_buffer)
 {
     double number = 0;
     unsigned char *after_end = NULL;
+    unsigned char number_c_string[64];
+    size_t i = 0;
 
-    if (input == NULL)
+    if ((input_buffer == NULL) || (input_buffer->content == NULL))
     {
         return NULL;
     }
 
-    number = strtod((const char*)input, (char**)&after_end);
-    if (input == after_end)
+    /* copy the number into a temporary buffer and zero terminate the string
+     * because the number in the input buffer is not necessariliy zero terminated
+     * and strtod only works with zero terminated strings */
+    for (i = 0; (i < (sizeof(number_c_string) - 1)) && can_access_at_index(input_buffer, i); i++)
+    {
+        if (strchr("0123456789+-eE.", buffer_at_offset(input_buffer)[i]) == NULL)
+        {
+            break;
+        }
+
+        number_c_string[i] = buffer_at_offset(input_buffer)[i];
+    }
+    number_c_string[i] = '\0';
+
+
+    number = strtod((const char*)number_c_string, (char**)&after_end);
+    if (number_c_string == after_end)
     {
         return NULL; /* parse_error */
     }
@@ -228,7 +245,8 @@ static const unsigned char *parse_number(cJSON * const item, const unsigned char
 
     item->type = cJSON_Number;
 
-    return after_end;
+    input_buffer->offset += (size_t)(after_end - number_c_string);
+    return buffer_at_offset(input_buffer);
 }
 
 /* don't ask me, but the original cJSON_SetNumberValue returns an integer or double */
@@ -1086,14 +1104,7 @@ static const unsigned  char *parse_value(cJSON * const item, parse_buffer * cons
     /* number */
     if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9'))))
     {
-        content_pointer = parse_number(item, buffer_at_offset(input_buffer));
-        if (content_pointer == NULL)
-        {
-            return NULL;
-        }
-
-        input_buffer->offset = (size_t)(content_pointer - input_buffer->content);
-        return buffer_at_offset(input_buffer);
+        return parse_number(item, input_buffer);
     }
     /* array */
     if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '['))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ if(ENABLE_CJSON_TEST)
         print_object
         print_value
         misc_tests
+        parse_with_opts
     )
 
     add_library(test-common common.c)

--- a/tests/parse_array.c
+++ b/tests/parse_array.c
@@ -51,7 +51,7 @@ static void assert_not_array(const char *json)
     buffer.length = strlen(json) + sizeof("");
     buffer.offset = 0;
 
-    TEST_ASSERT_NULL(parse_array(item, &buffer, &error_pointer, &global_hooks));
+    TEST_ASSERT_FALSE(parse_array(item, &buffer, &error_pointer, &global_hooks));
     assert_is_invalid(item);
 }
 
@@ -62,7 +62,7 @@ static void assert_parse_array(const char *json)
     buffer.length = strlen(json) + sizeof("");
     buffer.offset = 0;
 
-    TEST_ASSERT_NOT_NULL(parse_array(item, &buffer, &error_pointer, &global_hooks));
+    TEST_ASSERT_TRUE(parse_array(item, &buffer, &error_pointer, &global_hooks));
     assert_is_array(item);
 }
 

--- a/tests/parse_array.c
+++ b/tests/parse_array.c
@@ -46,13 +46,23 @@ static void assert_is_array(cJSON *array_item)
 
 static void assert_not_array(const char *json)
 {
-    TEST_ASSERT_NULL(parse_array(item, (const unsigned char*)json, &error_pointer, &global_hooks));
+    parse_buffer buffer;
+    buffer.content = (const unsigned char*)json;
+    buffer.length = strlen(json) + sizeof("");
+    buffer.offset = 0;
+
+    TEST_ASSERT_NULL(parse_array(item, &buffer, &error_pointer, &global_hooks));
     assert_is_invalid(item);
 }
 
 static void assert_parse_array(const char *json)
 {
-    TEST_ASSERT_NOT_NULL(parse_array(item, (const unsigned char*)json, &error_pointer, &global_hooks));
+    parse_buffer buffer;
+    buffer.content = (const unsigned char*)json;
+    buffer.length = strlen(json) + sizeof("");
+    buffer.offset = 0;
+
+    TEST_ASSERT_NOT_NULL(parse_array(item, &buffer, &error_pointer, &global_hooks));
     assert_is_array(item);
 }
 

--- a/tests/parse_array.c
+++ b/tests/parse_array.c
@@ -30,8 +30,6 @@
 
 static cJSON item[1];
 
-static const unsigned char *error_pointer = NULL;
-
 static void assert_is_array(cJSON *array_item)
 {
     TEST_ASSERT_NOT_NULL_MESSAGE(array_item, "Item is NULL.");
@@ -51,7 +49,7 @@ static void assert_not_array(const char *json)
     buffer.length = strlen(json) + sizeof("");
     buffer.offset = 0;
 
-    TEST_ASSERT_FALSE(parse_array(item, &buffer, &error_pointer, &global_hooks));
+    TEST_ASSERT_FALSE(parse_array(item, &buffer, &global_hooks));
     assert_is_invalid(item);
 }
 
@@ -62,7 +60,7 @@ static void assert_parse_array(const char *json)
     buffer.length = strlen(json) + sizeof("");
     buffer.offset = 0;
 
-    TEST_ASSERT_TRUE(parse_array(item, &buffer, &error_pointer, &global_hooks));
+    TEST_ASSERT_TRUE(parse_array(item, &buffer, &global_hooks));
     assert_is_array(item);
 }
 

--- a/tests/parse_number.c
+++ b/tests/parse_number.c
@@ -45,7 +45,12 @@ static void assert_is_number(cJSON *number_item)
 
 static void assert_parse_number(const char *string, int integer, double real)
 {
-    TEST_ASSERT_NOT_NULL(parse_number(item, (const unsigned char*)string));
+    parse_buffer buffer;
+    buffer.content = (const unsigned char*)string;
+    buffer.length = strlen(string) + sizeof("");
+    buffer.offset = 0;
+
+    TEST_ASSERT_NOT_NULL(parse_number(item, &buffer));
     assert_is_number(item);
     TEST_ASSERT_EQUAL_INT(integer, item->valueint);
     TEST_ASSERT_EQUAL_DOUBLE(real, item->valuedouble);

--- a/tests/parse_number.c
+++ b/tests/parse_number.c
@@ -50,7 +50,7 @@ static void assert_parse_number(const char *string, int integer, double real)
     buffer.length = strlen(string) + sizeof("");
     buffer.offset = 0;
 
-    TEST_ASSERT_NOT_NULL(parse_number(item, &buffer));
+    TEST_ASSERT_TRUE(parse_number(item, &buffer));
     assert_is_number(item);
     TEST_ASSERT_EQUAL_INT(integer, item->valueint);
     TEST_ASSERT_EQUAL_DOUBLE(real, item->valuedouble);

--- a/tests/parse_object.c
+++ b/tests/parse_object.c
@@ -59,7 +59,7 @@ static void assert_not_object(const char *json)
     parsebuffer.length = strlen(json) + sizeof("");
     parsebuffer.offset = 0;
 
-    TEST_ASSERT_NULL(parse_object(item, &parsebuffer, &error_pointer, &global_hooks));
+    TEST_ASSERT_FALSE(parse_object(item, &parsebuffer, &error_pointer, &global_hooks));
     assert_is_invalid(item);
     reset(item);
 }
@@ -71,7 +71,7 @@ static void assert_parse_object(const char *json)
     parsebuffer.length = strlen(json) + sizeof("");
     parsebuffer.offset = 0;
 
-    TEST_ASSERT_NOT_NULL(parse_object(item, &parsebuffer, &error_pointer, &global_hooks));
+    TEST_ASSERT_TRUE(parse_object(item, &parsebuffer, &error_pointer, &global_hooks));
     assert_is_object(item);
 }
 

--- a/tests/parse_object.c
+++ b/tests/parse_object.c
@@ -54,14 +54,24 @@ static void assert_is_child(cJSON *child_item, const char *name, int type)
 
 static void assert_not_object(const char *json)
 {
-    TEST_ASSERT_NULL(parse_object(item, (const unsigned char*)json, &error_pointer, &global_hooks));
+    parse_buffer parsebuffer;
+    parsebuffer.content = (const unsigned char*)json;
+    parsebuffer.length = strlen(json) + sizeof("");
+    parsebuffer.offset = 0;
+
+    TEST_ASSERT_NULL(parse_object(item, &parsebuffer, &error_pointer, &global_hooks));
     assert_is_invalid(item);
     reset(item);
 }
 
 static void assert_parse_object(const char *json)
 {
-    TEST_ASSERT_NOT_NULL(parse_object(item, (const unsigned char*)json, &error_pointer, &global_hooks));
+    parse_buffer parsebuffer;
+    parsebuffer.content = (const unsigned char*)json;
+    parsebuffer.length = strlen(json) + sizeof("");
+    parsebuffer.offset = 0;
+
+    TEST_ASSERT_NOT_NULL(parse_object(item, &parsebuffer, &error_pointer, &global_hooks));
     assert_is_object(item);
 }
 

--- a/tests/parse_object.c
+++ b/tests/parse_object.c
@@ -30,8 +30,6 @@
 
 static cJSON item[1];
 
-static const unsigned char *error_pointer = NULL;
-
 static void assert_is_object(cJSON *object_item)
 {
     TEST_ASSERT_NOT_NULL_MESSAGE(object_item, "Item is NULL.");
@@ -59,7 +57,7 @@ static void assert_not_object(const char *json)
     parsebuffer.length = strlen(json) + sizeof("");
     parsebuffer.offset = 0;
 
-    TEST_ASSERT_FALSE(parse_object(item, &parsebuffer, &error_pointer, &global_hooks));
+    TEST_ASSERT_FALSE(parse_object(item, &parsebuffer, &global_hooks));
     assert_is_invalid(item);
     reset(item);
 }
@@ -71,7 +69,7 @@ static void assert_parse_object(const char *json)
     parsebuffer.length = strlen(json) + sizeof("");
     parsebuffer.offset = 0;
 
-    TEST_ASSERT_TRUE(parse_object(item, &parsebuffer, &error_pointer, &global_hooks));
+    TEST_ASSERT_TRUE(parse_object(item, &parsebuffer, &global_hooks));
     assert_is_object(item);
 }
 

--- a/tests/parse_string.c
+++ b/tests/parse_string.c
@@ -52,7 +52,7 @@ static void assert_parse_string(const char *string, const char *expected)
     buffer.length = strlen(string) + sizeof("");
     buffer.offset = 0;
 
-    TEST_ASSERT_NOT_NULL_MESSAGE(parse_string(item, &buffer, &error_pointer, &global_hooks), "Couldn't parse string.");
+    TEST_ASSERT_TRUE_MESSAGE(parse_string(item, &buffer, &error_pointer, &global_hooks), "Couldn't parse string.");
     assert_is_string(item);
     TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, item->valuestring, "The parsed result isn't as expected.");
     global_hooks.deallocate(item->valuestring);
@@ -66,7 +66,7 @@ static void assert_not_parse_string(const char * const string)
     buffer.length = strlen(string) + sizeof("");
     buffer.offset = 0;
 
-    TEST_ASSERT_NULL_MESSAGE(parse_string(item, &buffer, &error_pointer, &global_hooks), "Malformed string should not be accepted.");
+    TEST_ASSERT_FALSE_MESSAGE(parse_string(item, &buffer, &error_pointer, &global_hooks), "Malformed string should not be accepted.");
     assert_is_invalid(item);
 }
 

--- a/tests/parse_string.c
+++ b/tests/parse_string.c
@@ -47,16 +47,28 @@ static void assert_is_string(cJSON *string_item)
 
 static void assert_parse_string(const char *string, const char *expected)
 {
-    TEST_ASSERT_NOT_NULL_MESSAGE(parse_string(item, (const unsigned char*)string, &error_pointer, &global_hooks), "Couldn't parse string.");
+    parse_buffer buffer;
+    buffer.content = (const unsigned char*)string;
+    buffer.length = strlen(string) + sizeof("");
+    buffer.offset = 0;
+
+    TEST_ASSERT_NOT_NULL_MESSAGE(parse_string(item, &buffer, &error_pointer, &global_hooks), "Couldn't parse string.");
     assert_is_string(item);
     TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, item->valuestring, "The parsed result isn't as expected.");
     global_hooks.deallocate(item->valuestring);
     item->valuestring = NULL;
 }
 
-#define assert_not_parse_string(string) \
-    TEST_ASSERT_NULL_MESSAGE(parse_string(item, (const unsigned char*)string, &error_pointer, &global_hooks), "Malformed string should not be accepted");\
-    assert_is_invalid(item)
+static void assert_not_parse_string(const char * const string)
+{
+    parse_buffer buffer;
+    buffer.content = (const unsigned char*)string;
+    buffer.length = strlen(string) + sizeof("");
+    buffer.offset = 0;
+
+    TEST_ASSERT_NULL_MESSAGE(parse_string(item, &buffer, &error_pointer, &global_hooks), "Malformed string should not be accepted.");
+    assert_is_invalid(item);
+}
 
 
 

--- a/tests/parse_string.c
+++ b/tests/parse_string.c
@@ -30,8 +30,6 @@
 
 static cJSON item[1];
 
-static const unsigned char *error_pointer = NULL;
-
 static void assert_is_string(cJSON *string_item)
 {
     TEST_ASSERT_NOT_NULL_MESSAGE(string_item, "Item is NULL.");
@@ -52,7 +50,7 @@ static void assert_parse_string(const char *string, const char *expected)
     buffer.length = strlen(string) + sizeof("");
     buffer.offset = 0;
 
-    TEST_ASSERT_TRUE_MESSAGE(parse_string(item, &buffer, &error_pointer, &global_hooks), "Couldn't parse string.");
+    TEST_ASSERT_TRUE_MESSAGE(parse_string(item, &buffer, &global_hooks), "Couldn't parse string.");
     assert_is_string(item);
     TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, item->valuestring, "The parsed result isn't as expected.");
     global_hooks.deallocate(item->valuestring);
@@ -66,7 +64,7 @@ static void assert_not_parse_string(const char * const string)
     buffer.length = strlen(string) + sizeof("");
     buffer.offset = 0;
 
-    TEST_ASSERT_FALSE_MESSAGE(parse_string(item, &buffer, &error_pointer, &global_hooks), "Malformed string should not be accepted.");
+    TEST_ASSERT_FALSE_MESSAGE(parse_string(item, &buffer, &global_hooks), "Malformed string should not be accepted.");
     assert_is_invalid(item);
 }
 

--- a/tests/parse_value.c
+++ b/tests/parse_value.c
@@ -44,7 +44,11 @@ static void assert_is_value(cJSON *value_item, int type)
 
 static void assert_parse_value(const char *string, int type)
 {
-    TEST_ASSERT_NOT_NULL(parse_value(item, (const unsigned char*)string, &error_pointer, &global_hooks));
+    parse_buffer buffer;
+    buffer.content = (const unsigned char*) string;
+    buffer.length = strlen(string) + sizeof("");
+    buffer.offset = 0;
+    TEST_ASSERT_NOT_NULL(parse_value(item, &buffer, &error_pointer, &global_hooks));
     assert_is_value(item, type);
 }
 

--- a/tests/parse_value.c
+++ b/tests/parse_value.c
@@ -48,7 +48,7 @@ static void assert_parse_value(const char *string, int type)
     buffer.content = (const unsigned char*) string;
     buffer.length = strlen(string) + sizeof("");
     buffer.offset = 0;
-    TEST_ASSERT_NOT_NULL(parse_value(item, &buffer, &error_pointer, &global_hooks));
+    TEST_ASSERT_TRUE(parse_value(item, &buffer, &error_pointer, &global_hooks));
     assert_is_value(item, type);
 }
 

--- a/tests/parse_value.c
+++ b/tests/parse_value.c
@@ -29,7 +29,6 @@
 #include "common.h"
 
 static cJSON item[1];
-const unsigned char *error_pointer = NULL;
 
 static void assert_is_value(cJSON *value_item, int type)
 {
@@ -48,7 +47,7 @@ static void assert_parse_value(const char *string, int type)
     buffer.content = (const unsigned char*) string;
     buffer.length = strlen(string) + sizeof("");
     buffer.offset = 0;
-    TEST_ASSERT_TRUE(parse_value(item, &buffer, &error_pointer, &global_hooks));
+    TEST_ASSERT_TRUE(parse_value(item, &buffer, &global_hooks));
     assert_is_value(item, type);
 }
 

--- a/tests/parse_with_opts.c
+++ b/tests/parse_with_opts.c
@@ -1,0 +1,70 @@
+/*
+  Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+#include "unity/examples/unity_config.h"
+#include "unity/src/unity.h"
+#include "common.h"
+
+static void parse_with_opts_should_handle_null(void)
+{
+    const char *error_pointer = NULL;
+    cJSON *item = NULL;
+    TEST_ASSERT_NULL_MESSAGE(cJSON_ParseWithOpts(NULL, &error_pointer, false), "Failed to handle NULL input.");
+    item = cJSON_ParseWithOpts("{}", NULL, false);
+    TEST_ASSERT_NOT_NULL_MESSAGE(item, "Failed to handle NULL error pointer.");
+    cJSON_Delete(item);
+    TEST_ASSERT_NULL_MESSAGE(cJSON_ParseWithOpts(NULL, NULL, false), "Failed to handle both NULL.");
+    TEST_ASSERT_NULL_MESSAGE(cJSON_ParseWithOpts("{", NULL, false), "Failed to handle NULL error pointer with parse error.");
+}
+
+static void parse_with_opts_should_handle_empty_strings(void)
+{
+    const char empty_string[] = "";
+    const char *error_pointer = NULL;
+    TEST_ASSERT_NULL(cJSON_ParseWithOpts(empty_string, NULL, false));
+    error_pointer = cJSON_GetErrorPtr();
+    TEST_ASSERT_EQUAL_INT(0, error_pointer - empty_string);
+    TEST_ASSERT_NULL(cJSON_ParseWithOpts(empty_string, &error_pointer, false));
+    TEST_ASSERT_EQUAL_INT(0, error_pointer - empty_string);
+}
+
+static void parse_with_opts_should_require_null_if_requested(void)
+{
+    cJSON *item = cJSON_ParseWithOpts("{}", NULL, true);
+    TEST_ASSERT_NOT_NULL(item);
+    cJSON_Delete(item);
+    item = cJSON_ParseWithOpts("{} \n", NULL, true);
+    TEST_ASSERT_NOT_NULL(item);
+    cJSON_Delete(item);
+    TEST_ASSERT_NULL(cJSON_ParseWithOpts("{}x", NULL, true));
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(parse_with_opts_should_handle_null);
+    RUN_TEST(parse_with_opts_should_handle_empty_strings);
+    RUN_TEST(parse_with_opts_should_require_null_if_requested);
+
+    return UNITY_END();
+}

--- a/tests/print_array.c
+++ b/tests/print_array.c
@@ -53,7 +53,7 @@ static void assert_print_array(const char * const expected, const char * const i
     unformatted_buffer.noalloc = true;
 
     memset(item, 0, sizeof(item));
-    TEST_ASSERT_NOT_NULL_MESSAGE(parse_array(item, &parsebuffer, &error_pointer, &global_hooks), "Failed to parse array.");
+    TEST_ASSERT_TRUE_MESSAGE(parse_array(item, &parsebuffer, &error_pointer, &global_hooks), "Failed to parse array.");
 
     TEST_ASSERT_TRUE_MESSAGE(print_array(item, 0, false, &unformatted_buffer, &global_hooks), "Failed to print unformatted string.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE(input, printed_unformatted, "Unformatted array is not correct.");

--- a/tests/print_array.c
+++ b/tests/print_array.c
@@ -29,7 +29,6 @@ static void assert_print_array(const char * const expected, const char * const i
     unsigned char printed_unformatted[1024];
     unsigned char printed_formatted[1024];
 
-    const unsigned char *error_pointer;
     cJSON item[1];
 
     printbuffer formatted_buffer;
@@ -53,7 +52,7 @@ static void assert_print_array(const char * const expected, const char * const i
     unformatted_buffer.noalloc = true;
 
     memset(item, 0, sizeof(item));
-    TEST_ASSERT_TRUE_MESSAGE(parse_array(item, &parsebuffer, &error_pointer, &global_hooks), "Failed to parse array.");
+    TEST_ASSERT_TRUE_MESSAGE(parse_array(item, &parsebuffer, &global_hooks), "Failed to parse array.");
 
     TEST_ASSERT_TRUE_MESSAGE(print_array(item, 0, false, &unformatted_buffer, &global_hooks), "Failed to print unformatted string.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE(input, printed_unformatted, "Unformatted array is not correct.");

--- a/tests/print_array.c
+++ b/tests/print_array.c
@@ -35,6 +35,11 @@ static void assert_print_array(const char * const expected, const char * const i
     printbuffer formatted_buffer;
     printbuffer unformatted_buffer;
 
+    parse_buffer parsebuffer;
+    parsebuffer.content = (const unsigned char*)input;
+    parsebuffer.length = strlen(input) + sizeof("");
+    parsebuffer.offset = 0;
+
     /* buffer for formatted printing */
     formatted_buffer.buffer = printed_formatted;
     formatted_buffer.length = sizeof(printed_formatted);
@@ -48,7 +53,7 @@ static void assert_print_array(const char * const expected, const char * const i
     unformatted_buffer.noalloc = true;
 
     memset(item, 0, sizeof(item));
-    TEST_ASSERT_NOT_NULL_MESSAGE(parse_array(item, (const unsigned char*)input, &error_pointer, &global_hooks), "Failed to parse array.");
+    TEST_ASSERT_NOT_NULL_MESSAGE(parse_array(item, &parsebuffer, &error_pointer, &global_hooks), "Failed to parse array.");
 
     TEST_ASSERT_TRUE_MESSAGE(print_array(item, 0, false, &unformatted_buffer, &global_hooks), "Failed to print unformatted string.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE(input, printed_unformatted, "Unformatted array is not correct.");

--- a/tests/print_object.c
+++ b/tests/print_object.c
@@ -34,6 +34,12 @@ static void assert_print_object(const char * const expected, const char * const 
 
     printbuffer formatted_buffer;
     printbuffer unformatted_buffer;
+    parse_buffer parsebuffer;
+
+    /* buffer for parsing */
+    parsebuffer.content = (const unsigned char*)input;
+    parsebuffer.length = strlen(input) + sizeof("");
+    parsebuffer.offset = 0;
 
     /* buffer for formatted printing */
     formatted_buffer.buffer = printed_formatted;
@@ -48,7 +54,7 @@ static void assert_print_object(const char * const expected, const char * const 
     unformatted_buffer.noalloc = true;
 
     memset(item, 0, sizeof(item));
-    TEST_ASSERT_NOT_NULL_MESSAGE(parse_object(item, (const unsigned char*)input, &error_pointer, &global_hooks), "Failed to parse object.");
+    TEST_ASSERT_NOT_NULL_MESSAGE(parse_object(item, &parsebuffer, &error_pointer, &global_hooks), "Failed to parse object.");
 
     TEST_ASSERT_TRUE_MESSAGE(print_object(item, 0, false, &unformatted_buffer, &global_hooks), "Failed to print unformatted string.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE(input, printed_unformatted, "Unformatted object is not correct.");

--- a/tests/print_object.c
+++ b/tests/print_object.c
@@ -54,7 +54,7 @@ static void assert_print_object(const char * const expected, const char * const 
     unformatted_buffer.noalloc = true;
 
     memset(item, 0, sizeof(item));
-    TEST_ASSERT_NOT_NULL_MESSAGE(parse_object(item, &parsebuffer, &error_pointer, &global_hooks), "Failed to parse object.");
+    TEST_ASSERT_TRUE_MESSAGE(parse_object(item, &parsebuffer, &error_pointer, &global_hooks), "Failed to parse object.");
 
     TEST_ASSERT_TRUE_MESSAGE(print_object(item, 0, false, &unformatted_buffer, &global_hooks), "Failed to print unformatted string.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE(input, printed_unformatted, "Unformatted object is not correct.");

--- a/tests/print_object.c
+++ b/tests/print_object.c
@@ -29,7 +29,6 @@ static void assert_print_object(const char * const expected, const char * const 
     unsigned char printed_unformatted[1024];
     unsigned char printed_formatted[1024];
 
-    const unsigned char *error_pointer;
     cJSON item[1];
 
     printbuffer formatted_buffer;
@@ -54,7 +53,7 @@ static void assert_print_object(const char * const expected, const char * const 
     unformatted_buffer.noalloc = true;
 
     memset(item, 0, sizeof(item));
-    TEST_ASSERT_TRUE_MESSAGE(parse_object(item, &parsebuffer, &error_pointer, &global_hooks), "Failed to parse object.");
+    TEST_ASSERT_TRUE_MESSAGE(parse_object(item, &parsebuffer, &global_hooks), "Failed to parse object.");
 
     TEST_ASSERT_TRUE_MESSAGE(print_object(item, 0, false, &unformatted_buffer, &global_hooks), "Failed to print unformatted string.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE(input, printed_unformatted, "Unformatted object is not correct.");

--- a/tests/print_value.c
+++ b/tests/print_value.c
@@ -46,7 +46,7 @@ static void assert_print_value(const char *input)
 
     memset(item, 0, sizeof(item));
 
-    TEST_ASSERT_NOT_NULL_MESSAGE(parse_value(item, &parsebuffer, &error_pointer, &global_hooks), "Failed to parse value.");
+    TEST_ASSERT_TRUE_MESSAGE(parse_value(item, &parsebuffer, &error_pointer, &global_hooks), "Failed to parse value.");
 
     TEST_ASSERT_TRUE_MESSAGE(print_value(item, 0, false, &buffer, &global_hooks), "Failed to print value.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE(input, buffer.buffer, "Printed value is not as expected.");

--- a/tests/print_value.c
+++ b/tests/print_value.c
@@ -34,14 +34,19 @@ static void assert_print_value(const char *input)
     const unsigned char *error_pointer = NULL;
     cJSON item[1];
     printbuffer buffer;
+    parse_buffer parsebuffer;
     buffer.buffer = printed;
     buffer.length = sizeof(printed);
     buffer.offset = 0;
     buffer.noalloc = true;
 
+    parsebuffer.content = (const unsigned char*)input;
+    parsebuffer.length = strlen(input) + sizeof("");
+    parsebuffer.offset = 0;
+
     memset(item, 0, sizeof(item));
 
-    TEST_ASSERT_NOT_NULL_MESSAGE(parse_value(item, (const unsigned char*)input, &error_pointer, &global_hooks), "Failed to parse value.");
+    TEST_ASSERT_NOT_NULL_MESSAGE(parse_value(item, &parsebuffer, &error_pointer, &global_hooks), "Failed to parse value.");
 
     TEST_ASSERT_TRUE_MESSAGE(print_value(item, 0, false, &buffer, &global_hooks), "Failed to print value.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE(input, buffer.buffer, "Printed value is not as expected.");

--- a/tests/print_value.c
+++ b/tests/print_value.c
@@ -31,7 +31,6 @@
 static void assert_print_value(const char *input)
 {
     unsigned char printed[1024];
-    const unsigned char *error_pointer = NULL;
     cJSON item[1];
     printbuffer buffer;
     parse_buffer parsebuffer;
@@ -46,7 +45,7 @@ static void assert_print_value(const char *input)
 
     memset(item, 0, sizeof(item));
 
-    TEST_ASSERT_TRUE_MESSAGE(parse_value(item, &parsebuffer, &error_pointer, &global_hooks), "Failed to parse value.");
+    TEST_ASSERT_TRUE_MESSAGE(parse_value(item, &parsebuffer, &global_hooks), "Failed to parse value.");
 
     TEST_ASSERT_TRUE_MESSAGE(print_value(item, 0, false, &buffer, &global_hooks), "Failed to print value.");
     TEST_ASSERT_EQUAL_STRING_MESSAGE(input, buffer.buffer, "Printed value is not as expected.");


### PR DESCRIPTION
This introduces parsing with a buffer struct that keeps the length of the input and the current offset. This is not useful by itself but can build the basis for later improvements like:

* Being able to parse '\0' inside of JSON strings
* Allow the usage of functions that don't care about the terminating zero and only rely on the length of the string instead.
* Now it's trivial to replace the error pointer with an error position.