### PR TITLE
Update types

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -263,7 +263,7 @@ static cJSON_bool parse_number(cJSON * const item, parse_buffer * const input_bu
     }
     else
     {
-        item->valueint = (int)number;
+        item->valueint = (cJSON_num)number;
     }
 
     item->type = cJSON_Number;
@@ -1983,7 +1983,7 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num)
         }
         else
         {
-            item->valueint = (int)num;
+            item->valueint = (cJSON_num)num;
         }
     }
 

--- a/cJSON.c
+++ b/cJSON.c
@@ -253,13 +253,13 @@ static cJSON_bool parse_number(cJSON * const item, parse_buffer * const input_bu
     item->valuedouble = number;
 
     /* use saturation in case of overflow */
-    if (number >= INT_MAX)
+    if (number >= CJSON_NUM_MAX)
     {
-        item->valueint = INT_MAX;
+        item->valueint = CJSON_NUM_MAX;
     }
-    else if (number <= INT_MIN)
+    else if (number <= CJSON_NUM_MIN)
     {
-        item->valueint = INT_MIN;
+        item->valueint = CJSON_NUM_MIN;
     }
     else
     {
@@ -275,13 +275,13 @@ static cJSON_bool parse_number(cJSON * const item, parse_buffer * const input_bu
 /* don't ask me, but the original cJSON_SetNumberValue returns an integer or double */
 CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number)
 {
-    if (number >= INT_MAX)
+    if (number >= CJSON_NUM_MAX)
     {
-        object->valueint = INT_MAX;
+        object->valueint = CJSON_NUM_MAX;
     }
-    else if (number <= INT_MIN)
+    else if (number <= CJSON_NUM_MIN)
     {
-        object->valueint = INT_MIN;
+        object->valueint = CJSON_NUM_MIN;
     }
     else
     {
@@ -310,9 +310,15 @@ static unsigned char* ensure(printbuffer * const p, size_t needed, const interna
         return NULL;
     }
 
-    if (needed > INT_MAX)
+    if ((p->length > 0) && (p->offset >= p->length))
     {
-        /* sizes bigger than INT_MAX are currently not supported */
+        /* make sure that offset is valid */
+        return NULL;
+    }
+
+    if (needed > CJSON_NUM_MAX)
+    {
+        /* sizes bigger than CJSON_NUM_MAX are currently not supported */
         return NULL;
     }
 
@@ -328,12 +334,12 @@ static unsigned char* ensure(printbuffer * const p, size_t needed, const interna
 
     /* calculate new buffer size */
     newsize = needed * 2;
-    if (newsize > INT_MAX)
+    if (newsize > CJSON_NUM_MAX)
     {
-        /* overflow of int, use INT_MAX if possible */
-        if (needed <= INT_MAX)
+        /* overflow of int, use CJSON_NUM_MAX if possible */
+        if (needed <= CJSON_NUM_MAX)
         {
-            newsize = INT_MAX;
+            newsize = CJSON_NUM_MAX;
         }
         else
         {
@@ -1973,13 +1979,13 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num)
         item->valuedouble = num;
 
         /* use saturation in case of overflow */
-        if (num >= INT_MAX)
+        if (num >= CJSON_NUM_MAX)
         {
-            item->valueint = INT_MAX;
+            item->valueint = CJSON_NUM_MAX;
         }
-        else if (num <= INT_MIN)
+        else if (num <= CJSON_NUM_MIN)
         {
-            item->valueint = INT_MIN;
+            item->valueint = CJSON_NUM_MIN;
         }
         else
         {

--- a/cJSON.c
+++ b/cJSON.c
@@ -310,12 +310,6 @@ static unsigned char* ensure(printbuffer * const p, size_t needed, const interna
         return NULL;
     }
 
-    if ((p->length > 0) && (p->offset >= p->length))
-    {
-        /* make sure that offset is valid */
-        return NULL;
-    }
-
     if (needed > CJSON_NUM_MAX)
     {
         /* sizes bigger than CJSON_NUM_MAX are currently not supported */

--- a/cJSON.c
+++ b/cJSON.c
@@ -2047,7 +2047,7 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateObject(void)
 }
 
 /* Create Arrays: */
-CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count)
+CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const cJSON_num *numbers, int count)
 {
     size_t i = 0;
     cJSON *n = NULL;

--- a/cJSON.h
+++ b/cJSON.h
@@ -51,6 +51,8 @@ extern "C"
 
 typedef int cJSON_num;
 typedef int cJSON_bool;
+#define CJSON_NUM_MAX INT_MAX
+#define CJSON_NUM_MIN INT_MIN
 
 /* The cJSON structure: */
 typedef struct cJSON

--- a/cJSON.h
+++ b/cJSON.h
@@ -49,6 +49,9 @@ extern "C"
 #define cJSON_IsReference 256
 #define cJSON_StringIsConst 512
 
+typedef long cJSON_num;
+typedef int cJSON_bool;
+
 /* The cJSON structure: */
 typedef struct cJSON
 {
@@ -64,7 +67,7 @@ typedef struct cJSON
     /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
     char *valuestring;
     /* The item's number, if type==cJSON_Number */
-    int valueint;
+    cJSON_num valueint;
     /* The item's number, if type==cJSON_Number */
     double valuedouble;
 
@@ -77,8 +80,6 @@ typedef struct cJSON_Hooks
       void *(*malloc_fn)(size_t sz);
       void (*free_fn)(void *ptr);
 } cJSON_Hooks;
-
-typedef int cJSON_bool;
 
 #if !defined(__WINDOWS__) && (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
 #define __WINDOWS__
@@ -173,7 +174,7 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateArray(void);
 CJSON_PUBLIC(cJSON *) cJSON_CreateObject(void);
 
 /* These utilities create an Array of count items. */
-CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const cJSON_num *numbers, int count);
 CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count);
 CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count);
 CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char **strings, int count);

--- a/cJSON.h
+++ b/cJSON.h
@@ -49,7 +49,7 @@ extern "C"
 #define cJSON_IsReference 256
 #define cJSON_StringIsConst 512
 
-typedef long cJSON_num;
+typedef int cJSON_num;
 typedef int cJSON_bool;
 
 /* The cJSON structure: */


### PR DESCRIPTION
This is motivated by using this library in AVR land, where an int is two bytes long.
This patch allows one to change the type of int used easily.