### PR TITLE
Revert "parse_number: Switch to C library's strtod"

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -180,39 +180,85 @@ CJSON_PUBLIC(void) cJSON_Delete(cJSON *c)
 /* Parse the input text to generate a number, and populate the result into item. */
 static const unsigned char *parse_number(cJSON * const item, const unsigned char * const input)
 {
-    double number = 0;
-    unsigned char *after_end = NULL;
+    const unsigned char *num = input;
+    double n = 0;
+    double sign = 1;
+    double scale = 0;
+    int subscale = 0;
+    int signsubscale = 1;
 
-    if (input == NULL)
+    /* Has sign? */
+    if (*num == '-')
     {
-        return NULL;
+        sign = -1;
+        num++;
+    }
+    /* is zero */
+    if (*num == '0')
+    {
+        num++;
+    }
+    /* Number? */
+    if ((*num >= '1') && (*num <= '9'))
+    {
+        do
+        {
+            n = (n * 10.0) + (*num++ - '0');
+        }
+        while ((*num >= '0') && (*num<='9'));
+    }
+    /* Fractional part? */
+    if ((*num == '.') && (num[1] >= '0') && (num[1] <= '9'))
+    {
+        num++;
+        do
+        {
+            n = (n  *10.0) + (*num++ - '0');
+            scale--;
+        } while ((*num >= '0') && (*num <= '9'));
+    }
+    /* Exponent? */
+    if ((*num == 'e') || (*num == 'E'))
+    {
+        num++;
+        /* With sign? */
+        if (*num == '+')
+        {
+            num++;
+        }
+        else if (*num == '-')
+        {
+            signsubscale = -1;
+            num++;
+        }
+        /* Number? */
+        while ((*num>='0') && (*num<='9'))
+        {
+            subscale = (subscale * 10) + (*num++ - '0');
+        }
     }
 
-    number = strtod((const char*)input, (char**)&after_end);
-    if (input == after_end)
-    {
-        return NULL; /* parse_error */
-    }
+    /* number = +/- number.fraction * 10^+/- exponent */
+    n = sign * n * pow(10.0, (scale + subscale * signsubscale));
 
-    item->valuedouble = number;
-
+    item->valuedouble = n;
     /* use saturation in case of overflow */
-    if (number >= INT_MAX)
+    if (n >= INT_MAX)
     {
         item->valueint = INT_MAX;
     }
-    else if (number <= INT_MIN)
+    else if (n <= INT_MIN)
     {
         item->valueint = INT_MIN;
     }
     else
     {
-        item->valueint = (int)number;
+        item->valueint = (int)n;
     }
 
     item->type = cJSON_Number;
 
-    return after_end;
+    return num;
 }
 
 /* don't ask me, but the original cJSON_SetNumberValue returns an integer or double */


### PR DESCRIPTION
Unfortunately, strtod's behaviour differs based on locale. When the user's locale uses a "decimal comma" instead of a "deicmal point", strtod can eat the comma that separates this item from the next item, resulting in a failure to parse objects with more than one item.