### PR TITLE
Locale independence

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,8 +392,9 @@ The maximum length of a floating point literal that cJSON supports is currently 
 In general cJSON is **not thread safe**.
 
 However it is thread safe under the following conditions:
-* You don't use `cJSON_GetErrorPtr` (you can use the `return_parse_end` parameter of `cJSON_ParseWithOpts` instead)
-* You only ever call `cJSON_InitHooks` before using cJSON in any threads.
+* `cJSON_GetErrorPtr` is never used (the `return_parse_end` parameter of `cJSON_ParseWithOpts` can be used instead)
+* `cJSON_InitHooks` is only ever called before using cJSON in any threads.
+* `setlocale` is never called before all calls to cJSON functions have returned.
 
 # Enjoy cJSON!
 

--- a/cJSON.c
+++ b/cJSON.c
@@ -417,7 +417,7 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     unsigned char *output_pointer = NULL;
     double d = item->valuedouble;
     int length = 0;
-    cJSON_bool trim_zeroes = true; /* should at the end be removed? */
+    cJSON_bool trim_zeroes = true; /* should zeroes at the end be removed? */
 
     if (output_buffer == NULL)
     {

--- a/cJSON.c
+++ b/cJSON.c
@@ -381,34 +381,24 @@ static void update_offset(printbuffer * const buffer)
 }
 
 /* Removes trailing zeroes from the end of a printed number */
-static cJSON_bool trim_trailing_zeroes(printbuffer * const buffer)
+static int trim_trailing_zeroes(const unsigned char * const number, int length, const unsigned char decimal_point)
 {
-    size_t offset = 0;
-    unsigned char *content = NULL;
-
-    if ((buffer == NULL) || (buffer->buffer == NULL) || (buffer->offset < 1))
+    if ((number == NULL) || (length <= 0))
     {
-        return false;
+        return -1;
     }
 
-    offset = buffer->offset - 1;
-    content = buffer->buffer;
-
-    while ((offset > 0) && (content[offset] == '0'))
+    while ((length > 0) && (number[length - 1] == '0'))
     {
-        offset--;
+        length--;
     }
-    if ((offset > 0) && (content[offset] == '.'))
+    if ((length > 0) && (number[length - 1] == decimal_point))
     {
-        offset--;
+        /* remove trailing decimal_point */
+        length--;
     }
 
-    offset++;
-    content[offset] = '\0';
-
-    buffer->offset = offset;
-
-    return true;
+    return length;
 }
 
 /* Render the number nicely from the given item into a string. */
@@ -417,16 +407,12 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     unsigned char *output_pointer = NULL;
     double d = item->valuedouble;
     int length = 0;
+    size_t i = 0;
     cJSON_bool trim_zeroes = true; /* should zeroes at the end be removed? */
+    unsigned char number_buffer[64]; /* temporary buffer to print the number into */
+    unsigned char decimal_point = get_decimal_point();
 
     if (output_buffer == NULL)
-    {
-        return false;
-    }
-
-    /* This is a nice tradeoff. */
-    output_pointer = ensure(output_buffer, 64, hooks);
-    if (output_pointer == NULL)
     {
         return false;
     }
@@ -434,36 +420,61 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     /* This checks for NaN and Infinity */
     if ((d * 0) != 0)
     {
-        length = sprintf((char*)output_pointer, "null");
+        length = sprintf((char*)number_buffer, "null");
     }
     else if ((fabs(floor(d) - d) <= DBL_EPSILON) && (fabs(d) < 1.0e60))
     {
         /* integer */
-        length = sprintf((char*)output_pointer, "%.0f", d);
+        length = sprintf((char*)number_buffer, "%.0f", d);
         trim_zeroes = false; /* don't remove zeroes for "big integers" */
     }
     else if ((fabs(d) < 1.0e-6) || (fabs(d) > 1.0e9))
     {
-        length = sprintf((char*)output_pointer, "%e", d);
+        length = sprintf((char*)number_buffer, "%e", d);
         trim_zeroes = false; /* don't remove zeroes in engineering notation */
     }
     else
     {
-        length = sprintf((char*)output_pointer, "%f", d);
+        length = sprintf((char*)number_buffer, "%f", d);
     }
 
-    /* sprintf failed */
-    if (length < 0)
+    /* sprintf failed or buffer overrun occured */
+    if ((length < 0) || (length > (int)(sizeof(number_buffer) - 1)))
     {
         return false;
     }
 
-    output_buffer->offset += (size_t)length;
-
     if (trim_zeroes)
     {
-        return trim_trailing_zeroes(output_buffer);
+        length = trim_trailing_zeroes(number_buffer, length, decimal_point);
+        if (length <= 0)
+        {
+            return false;
+        }
     }
+
+    /* reserve appropriate space in the output */
+    output_pointer = ensure(output_buffer, (size_t)length, hooks);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+
+    /* copy the printed number to the output and replace locale
+     * dependent decimal point with '.' */
+    for (i = 0; i < ((size_t)length); i++)
+    {
+        if (number_buffer[i] == decimal_point)
+        {
+            output_pointer[i] = '.';
+            continue;
+        }
+
+        output_pointer[i] = number_buffer[i];
+    }
+    output_pointer[i] = '\0';
+
+    output_buffer->offset += (size_t)length;
 
     return true;
 }

--- a/cJSON.h
+++ b/cJSON.h
@@ -133,7 +133,7 @@ CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON *item);
 /* Render a cJSON entity to text using a buffered strategy. prebuffer is a guess at the final size. guessing well reduces reallocation. fmt=0 gives unformatted, =1 gives formatted */
 CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt);
 /* Render a cJSON entity to text using a buffer already allocated in memory with given length. Returns 1 on success and 0 on failure. */
-/* NOTE: If you are printing numbers, the buffer hat to be 63 bytes bigger then the printed JSON (worst case) */
+/* NOTE: cJSON is not always 100% accurate in estimating how much memory it will use, so to be safe allocate 5 bytes more than you actually need */
 CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format);
 /* Delete a cJSON entity and all subentities. */
 CJSON_PUBLIC(void) cJSON_Delete(cJSON *c);

--- a/test.c
+++ b/test.c
@@ -53,8 +53,8 @@ static int print_preallocated(cJSON *root)
     out = cJSON_Print(root);
 
     /* create buffer to succeed */
-    /* the extra 64 bytes are in case a floating point value is printed */
-    len = strlen(out) + 64;
+    /* the extra 5 bytes are because of inaccuracies when reserving memory */
+    len = strlen(out) + 5;
     buf = (char*)malloc(len);
     if (buf == NULL)
     {

--- a/tests/print_number.c
+++ b/tests/print_number.c
@@ -89,17 +89,11 @@ static void print_number_should_print_non_number(void)
 
 static void trim_trailing_zeroes_should_trim_trailing_zeroes(void)
 {
-    printbuffer buffer;
-    unsigned char number[100];
-    buffer.length = sizeof(number);
-    buffer.buffer = number;
-
-    strcpy((char*)number, "10.00");
-    buffer.offset = sizeof("10.00") - 1;
-    TEST_ASSERT_TRUE(trim_trailing_zeroes(&buffer));
-    TEST_ASSERT_EQUAL_UINT8('\0', buffer.buffer[buffer.offset]);
-    TEST_ASSERT_EQUAL_STRING("10", number);
-    TEST_ASSERT_EQUAL_UINT(sizeof("10") - 1, buffer.offset);
+    TEST_ASSERT_EQUAL_INT(2, trim_trailing_zeroes((const unsigned char*)"10.00", (int)(sizeof("10.00") - 1), '.'));
+    TEST_ASSERT_EQUAL_INT(0, trim_trailing_zeroes((const unsigned char*)".00", (int)(sizeof(".00") - 1), '.'));
+    TEST_ASSERT_EQUAL_INT(0, trim_trailing_zeroes((const unsigned char*)"00", (int)(sizeof("00") - 1), '.'));
+    TEST_ASSERT_EQUAL_INT(-1, trim_trailing_zeroes(NULL, 10, '.'));
+    TEST_ASSERT_EQUAL_INT(-1, trim_trailing_zeroes((const unsigned char*)"", 0, '.'));
 }
 
 int main(void)


### PR DESCRIPTION
This addresses #145.

Both `parse_number` and `print_number` weren't capable of handling locales where the decimal point is not `'.'`.

To fix this the current decimal-point is fetched via `localeconv`.

`parse_number` now parses the number into a buffer and replaces the `'.'` with the decimal-point character of the current locale.

`print_number` prints the number to a temporary buffer and then replaces the decimal-point with `'.'` when copying the number to the output. This also means that the size of the printed number is now known before space in the printbuffer is reserved, thereby loosening the space requirements for `cJSON_PrintPreallocated`.