### PR TITLE
Makefile: GCC version guard for -fstack-protector-strong

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,17 @@ INSTALL_LIBRARY_PATH = $(DESTDIR)$(PREFIX)/$(LIBRARY_PATH)
 
 INSTALL ?= cp -a
 
-R_CFLAGS = -fPIC -std=c89 -pedantic -Wall -Werror -Wstrict-prototypes -Wwrite-strings -Wshadow -Winit-self -Wcast-align -Wformat=2 -Wmissing-prototypes -Wstrict-overflow=2 -Wcast-qual -Wc++-compat -Wundef -Wswitch-default -Wconversion -fstack-protector-strong $(CFLAGS)
+# validate gcc version for use fstack-protector-strong
+MIN_GCC_VERSION = "4.9"
+GCC_VERSION := "`gcc -dumpversion`"
+IS_GCC_ABOVE_MIN_VERSION := $(shell expr "$(GCC_VERSION)" ">=" "$(MIN_GCC_VERSION)")
+ifeq "$(IS_GCC_ABOVE_MIN_VERSION)" "1"
+    CFLAGS += -fstack-protector-strong
+else
+    CFLAGS += -fstack-protector
+endif
+
+R_CFLAGS = -fPIC -std=c89 -pedantic -Wall -Werror -Wstrict-prototypes -Wwrite-strings -Wshadow -Winit-self -Wcast-align -Wformat=2 -Wmissing-prototypes -Wstrict-overflow=2 -Wcast-qual -Wc++-compat -Wundef -Wswitch-default -Wconversion $(CFLAGS)
 
 uname := $(shell sh -c 'uname -s 2>/dev/null || echo false')
 


### PR DESCRIPTION
Hi,

[#163](https://github.com/DaveGamble/cJSON/issues/163)

l test it with gcc 4.8

look [Stackoverflow](http://stackoverflow.com/questions/42419301/makefile-emit-warning-gcc-version-is-lower-than-4-8-0/42425596)

Thank you!!