### PR TITLE
MSVC compiler handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,37 +16,46 @@ set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT
 set(custom_compiler_flags)
 
 include(CheckCCompilerFlag)
-option(ENABLE_CUSTOM_COMPILER_FLAGS "Enables custom compiler flags for Clang and GCC" ON)
+option(ENABLE_CUSTOM_COMPILER_FLAGS "Enables custom compiler flags" ON)
 if (ENABLE_CUSTOM_COMPILER_FLAGS)
-    list(APPEND custom_compiler_flags
-        -std=c89
-        -pedantic
-        -Wall
-        -Wextra
-        -Werror
-        -Wstrict-prototypes
-        -Wwrite-strings
-        -Wshadow
-        -Winit-self
-        -Wcast-align
-        -Wformat=2
-        -Wmissing-prototypes
-        -Wstrict-overflow=2
-        -Wcast-qual
-        -Wundef
-        -Wswitch-default
-        -Wconversion
-        -Wc++-compat
-        -fstack-protector-strong
-        -Wcomma
-        -Wdouble-promotion
-        -Wparentheses
-        -Wformat-overflow
-        -Wunused-macros
-        -Wmissing-variable-declarations
-        -Wused-but-marked-unused
-        -Wswitch-enum
+    if (("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang") OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU"))
+        list(APPEND custom_compiler_flags
+            -std=c89
+            -pedantic
+            -Wall
+            -Wextra
+            -Werror
+            -Wstrict-prototypes
+            -Wwrite-strings
+            -Wshadow
+            -Winit-self
+            -Wcast-align
+            -Wformat=2
+            -Wmissing-prototypes
+            -Wstrict-overflow=2
+            -Wcast-qual
+            -Wundef
+            -Wswitch-default
+            -Wconversion
+            -Wc++-compat
+            -fstack-protector-strong
+            -Wcomma
+            -Wdouble-promotion
+            -Wparentheses
+            -Wformat-overflow
+            -Wunused-macros
+            -Wmissing-variable-declarations
+            -Wused-but-marked-unused
+            -Wswitch-enum
         )
+    elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+        list(APPEND custom_compiler_flags
+            /GS
+            /Za
+            /sdl
+            /W4
+        )
+    endif()
 endif()
 
 option(ENABLE_SANITIZERS "Enables AddressSanitizer and UndefinedBehaviorSanitizer." OFF)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can change the build process with a list of different options that you can p
 * `-DENABLE_CJSON_TEST=On`: Enable building the tests. (on by default)
 * `-DENABLE_CJSON_UTILS=On`: Enable building cJSON_Utils. (off by default)
 * `-DENABLE_TARGET_EXPORT=On`: Enable the export of CMake targets. Turn off if it makes problems. (on by default)
-* `-DENABLE_CUSTOM_COMPILER_FLAGS=On`: Enable custom compiler flags (currently for Clang and GCC). Turn off if it makes problems. (on by default)
+* `-DENABLE_CUSTOM_COMPILER_FLAGS=On`: Enable custom compiler flags (currently for Clang, GCC and MSVC). Turn off if it makes problems. (on by default)
 * `-DENABLE_VALGRIND=On`: Run tests with [valgrind](http://valgrind.org). (off by default)
 * `-DENABLE_SANITIZERS=On`: Compile cJSON with [AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) and [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) enabled (if possible). (off by default)
 * `-DBUILD_SHARED_LIBS=On`: Build the shared libraries. (on by default)

--- a/cJSON.c
+++ b/cJSON.c
@@ -23,6 +23,11 @@
 /* cJSON */
 /* JSON parser in C. */
 
+/* disable warnings about old C89 functions in MSVC */
+#if !defined(_CRT_SECURE_NO_DEPRECATE) && defined(_MSC_VER)
+#define _CRT_SECURE_NO_DEPRECATE
+#endif
+
 #ifdef __GNUC__
 #pragma GCC visibility push(default)
 #endif

--- a/cJSON.c
+++ b/cJSON.c
@@ -1828,7 +1828,7 @@ CJSON_PUBLIC(void) cJSON_AddItemToObject(cJSON *object, const char *string, cJSO
     item->type &= ~cJSON_StringIsConst;
 }
 
-#if defined (__clang__) || ((__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
     #pragma GCC diagnostic push
 #endif
 #ifdef __GNUC__
@@ -1850,7 +1850,7 @@ CJSON_PUBLIC(void) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJ
     item->type |= cJSON_StringIsConst;
     cJSON_AddItemToArray(object, item);
 }
-#if defined (__clang__) || ((__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
     #pragma GCC diagnostic pop
 #endif
 

--- a/cJSON.c
+++ b/cJSON.c
@@ -31,6 +31,11 @@
 #ifdef __GNUC__
 #pragma GCC visibility push(default)
 #endif
+#if defined(_MSC_VER)
+#pragma warning (push)
+/* disable warning about single line comments in system headers */
+#pragma warning (disable : 4001)
+#endif
 
 #include <string.h>
 #include <stdio.h>
@@ -41,6 +46,9 @@
 #include <ctype.h>
 #include <locale.h>
 
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 #ifdef __GNUC__
 #pragma GCC visibility pop
 #endif

--- a/cJSON.c
+++ b/cJSON.c
@@ -147,7 +147,8 @@ static unsigned char* cJSON_strdup(const unsigned char* string, const internal_h
     }
 
     length = strlen((const char*)string) + sizeof("");
-    if (!(copy = (unsigned char*)hooks->allocate(length)))
+    copy = (unsigned char*)hooks->allocate(length);
+    if (copy == NULL)
     {
         return NULL;
     }

--- a/cJSON.c
+++ b/cJSON.c
@@ -114,7 +114,27 @@ typedef struct internal_hooks
     void *(*reallocate)(void *pointer, size_t size);
 } internal_hooks;
 
-static internal_hooks global_hooks = { malloc, free, realloc };
+#if defined(_MSC_VER)
+/* work around MSVC error C2322: '...' address of dillimport '...' is not static */
+static void *internal_malloc(size_t size)
+{
+    return malloc(size);
+}
+static void internal_free(void *pointer)
+{
+    free(pointer);
+}
+static void *internal_realloc(void *pointer, size_t size)
+{
+    return realloc(pointer, size);
+}
+#else
+#define internal_malloc malloc
+#define internal_free free
+#define internal_realloc realloc
+#endif
+
+static internal_hooks global_hooks = { internal_malloc, internal_free, internal_realloc };
 
 static unsigned char* cJSON_strdup(const unsigned char* string, const internal_hooks * const hooks)
 {

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -24,13 +24,18 @@
 #if !defined(_CRT_SECURE_NO_DEPRECATE) && defined(_MSC_VER)
 #define _CRT_SECURE_NO_DEPRECATE
 #endif
+
+#ifdef __GNUCC__
 #pragma GCC visibility push(default)
+#endif
 #include <ctype.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <limits.h>
+#ifdef __GNUCC__
 #pragma GCC visibility pop
+#endif
 
 #include "cJSON_Utils.h"
 

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -28,11 +28,21 @@
 #ifdef __GNUCC__
 #pragma GCC visibility push(default)
 #endif
+#if defined(_MSC_VER)
+#pragma warning (push)
+/* disable warning about single line comments in system headers */
+#pragma warning (disable : 4001)
+#endif
+
 #include <ctype.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <limits.h>
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 #ifdef __GNUCC__
 #pragma GCC visibility pop
 #endif

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -20,6 +20,10 @@
   THE SOFTWARE.
 */
 
+/* disable warnings about old C89 functions in MSVC */
+#if !defined(_CRT_SECURE_NO_DEPRECATE) && defined(_MSC_VER)
+#define _CRT_SECURE_NO_DEPRECATE
+#endif
 #pragma GCC visibility push(default)
 #include <ctype.h>
 #include <string.h>


### PR DESCRIPTION
This adds custom compiler flags for the MSVC compiler and handles all warnings.

`/We` is not enabled because I don't have any continuous integration in place that could catch it if I break the build.