### PR TITLE
Null pointer fixes

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -2206,7 +2206,7 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count)
     cJSON *p = NULL;
     cJSON *a = NULL;
 
-    if (count < 0)
+    if ((count < 0) || (numbers == NULL))
     {
         return NULL;
     }

--- a/cJSON.c
+++ b/cJSON.c
@@ -2278,7 +2278,7 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char **strings, int count)
     cJSON *p = NULL;
     cJSON *a = NULL;
 
-    if (count < 0)
+    if ((count < 0) || (strings == NULL))
     {
         return NULL;
     }

--- a/cJSON.c
+++ b/cJSON.c
@@ -1653,17 +1653,25 @@ static cJSON_bool print_object(const cJSON * const item, printbuffer * const out
 /* Get Array size/item / object item. */
 CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON *array)
 {
-    cJSON *c = array->child;
-    size_t i = 0;
-    while(c)
+    cJSON *child = NULL;
+    size_t size = 0;
+
+    if (array == NULL)
     {
-        i++;
-        c = c->next;
+        return 0;
+    }
+
+    child = array->child;
+
+    while(child != NULL)
+    {
+        size++;
+        child = child->next;
     }
 
     /* FIXME: Can overflow here. Cannot be fixed without breaking the API */
 
-    return (int)i;
+    return (int)size;
 }
 
 static cJSON* get_array_item(const cJSON *array, size_t index)

--- a/cJSON.c
+++ b/cJSON.c
@@ -1826,7 +1826,7 @@ CJSON_PUBLIC(void) cJSON_AddItemToObject(cJSON *object, const char *string, cJSO
 /* Add an item to an object with constant string as key */
 CJSON_PUBLIC(void) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item)
 {
-    if (!item)
+    if ((item == NULL) || (string == NULL))
     {
         return;
     }

--- a/cJSON.c
+++ b/cJSON.c
@@ -1122,7 +1122,7 @@ CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buf, const i
 {
     printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
 
-    if (len < 0)
+    if ((len < 0) || (buf == NULL))
     {
         return false;
     }

--- a/cJSON.c
+++ b/cJSON.c
@@ -2390,6 +2390,12 @@ fail:
 CJSON_PUBLIC(void) cJSON_Minify(char *json)
 {
     unsigned char *into = (unsigned char*)json;
+
+    if (json == NULL)
+    {
+        return;
+    }
+
     while (*json)
     {
         if (*json == ' ')

--- a/cJSON.c
+++ b/cJSON.c
@@ -2242,7 +2242,7 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count)
     cJSON *p = NULL;
     cJSON *a = NULL;
 
-    if (count < 0)
+    if ((count < 0) || (numbers == NULL))
     {
         return NULL;
     }

--- a/cJSON.c
+++ b/cJSON.c
@@ -1854,6 +1854,11 @@ CJSON_PUBLIC(void) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item)
 
 CJSON_PUBLIC(void) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item)
 {
+    if ((object == NULL) || (string == NULL))
+    {
+        return;
+    }
+
     cJSON_AddItemToObject(object, string, create_reference(item, &global_hooks));
 }
 

--- a/cJSON.c
+++ b/cJSON.c
@@ -1111,6 +1111,7 @@ CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON
 
     if (!print_value(item, &p))
     {
+        global_hooks.deallocate(p.buffer);
         return NULL;
     }
 

--- a/cJSON.c
+++ b/cJSON.c
@@ -1756,16 +1756,23 @@ static void suffix_object(cJSON *prev, cJSON *item)
 /* Utility for handling references. */
 static cJSON *create_reference(const cJSON *item, const internal_hooks * const hooks)
 {
-    cJSON *ref = cJSON_New_Item(hooks);
-    if (!ref)
+    cJSON *reference = NULL;
+    if (item == NULL)
     {
         return NULL;
     }
-    memcpy(ref, item, sizeof(cJSON));
-    ref->string = NULL;
-    ref->type |= cJSON_IsReference;
-    ref->next = ref->prev = NULL;
-    return ref;
+
+    reference = cJSON_New_Item(hooks);
+    if (reference == NULL)
+    {
+        return NULL;
+    }
+
+    memcpy(reference, item, sizeof(cJSON));
+    reference->string = NULL;
+    reference->type |= cJSON_IsReference;
+    reference->next = reference->prev = NULL;
+    return reference;
 }
 
 /* Add item to array/object. */

--- a/cJSON.c
+++ b/cJSON.c
@@ -2171,7 +2171,7 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count)
     cJSON *p = NULL;
     cJSON *a = NULL;
 
-    if (count < 0)
+    if ((count < 0) || (numbers == NULL))
     {
         return NULL;
     }

--- a/cJSON.c
+++ b/cJSON.c
@@ -1963,7 +1963,7 @@ CJSON_PUBLIC(void) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newit
 
 CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement)
 {
-    if ((parent == NULL) || (replacement == NULL))
+    if ((parent == NULL) || (replacement == NULL) || (item == NULL))
     {
         return false;
     }

--- a/cJSON.c
+++ b/cJSON.c
@@ -2008,7 +2008,7 @@ CJSON_PUBLIC(void) cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newi
 
 static cJSON_bool replace_item_in_object(cJSON *object, const char *string, cJSON *replacement, cJSON_bool case_sensitive)
 {
-    if (replacement == NULL)
+    if ((replacement == NULL) || (string == NULL))
     {
         return false;
     }

--- a/cJSON.c
+++ b/cJSON.c
@@ -1790,6 +1790,11 @@ CJSON_PUBLIC(void) cJSON_AddItemToArray(cJSON *array, cJSON *item)
 
 CJSON_PUBLIC(void) cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item)
 {
+    if (item == NULL)
+    {
+        return;
+    }
+
     /* call cJSON_AddItemToObjectCS for code reuse */
     cJSON_AddItemToObjectCS(object, (char*)cJSON_strdup((const unsigned char*)string, &global_hooks), item);
     /* remove cJSON_StringIsConst flag */

--- a/cJSON.c
+++ b/cJSON.c
@@ -1844,6 +1844,11 @@ CJSON_PUBLIC(void) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJ
 
 CJSON_PUBLIC(void) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item)
 {
+    if (array == NULL)
+    {
+        return;
+    }
+
     cJSON_AddItemToArray(array, create_reference(item, &global_hooks));
 }
 

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -1228,7 +1228,14 @@ static void create_patches(cJSON * const patches, const unsigned char * const pa
 
 CJSON_PUBLIC(cJSON *) cJSONUtils_GeneratePatches(cJSON * const from, cJSON * const to)
 {
-    cJSON *patches = cJSON_CreateArray();
+    cJSON *patches = NULL;
+
+    if ((from == NULL) || (to == NULL))
+    {
+        return NULL;
+    }
+
+    patches = cJSON_CreateArray();
     create_patches(patches, (const unsigned char*)"", from, to, false);
 
     return patches;

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -162,6 +162,11 @@ CJSON_PUBLIC(char *) cJSONUtils_FindPointerFromObjectTo(const cJSON * const obje
     size_t child_index = 0;
     cJSON *current_child = 0;
 
+    if ((object == NULL) || (target == NULL))
+    {
+        return NULL;
+    }
+
     if (object == target)
     {
         /* found */

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -1243,7 +1243,14 @@ CJSON_PUBLIC(cJSON *) cJSONUtils_GeneratePatches(cJSON * const from, cJSON * con
 
 CJSON_PUBLIC(cJSON *) cJSONUtils_GeneratePatchesCaseSensitive(cJSON * const from, cJSON * const to)
 {
-    cJSON *patches = cJSON_CreateArray();
+    cJSON *patches = NULL;
+
+    if ((from == NULL) || (to == NULL))
+    {
+        return NULL;
+    }
+
+    patches = cJSON_CreateArray();
     create_patches(patches, (const unsigned char*)"", from, to, true);
 
     return patches;

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -1043,7 +1043,14 @@ CJSON_PUBLIC(int) cJSONUtils_ApplyPatchesCaseSensitive(cJSON * const object, con
 
 static void compose_patch(cJSON * const patches, const unsigned char * const operation, const unsigned char * const path, const unsigned char *suffix, const cJSON * const value)
 {
-    cJSON *patch = cJSON_CreateObject();
+    cJSON *patch = NULL;
+
+    if ((patches == NULL) || (operation == NULL) || (path == NULL))
+    {
+        return;
+    }
+
+    patch = cJSON_CreateObject();
     if (patch == NULL)
     {
         return;

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -262,6 +262,12 @@ static cJSON_bool decode_array_index_from_pointer(const unsigned char * const po
 static cJSON *get_item_from_pointer(cJSON * const object, const char * pointer, const cJSON_bool case_sensitive)
 {
     cJSON *current_element = object;
+
+    if (pointer == NULL)
+    {
+        return NULL;
+    }
+
     /* follow path of the pointer */
     while ((pointer[0] == '/') && (current_element != NULL))
     {

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -550,6 +550,10 @@ static cJSON *sort_list(cJSON *list, const cJSON_bool case_sensitive)
 
 static void sort_object(cJSON * const object, const cJSON_bool case_sensitive)
 {
+    if (object == NULL)
+    {
+        return;
+    }
     object->child = sort_list(object->child, case_sensitive);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -84,7 +84,8 @@ if(ENABLE_CJSON_TEST)
 
         set (cjson_utils_tests
             json_patch_tests
-            old_utils_tests)
+            old_utils_tests
+            misc_utils_tests)
 
         foreach (cjson_utils_test ${cjson_utils_tests})
             add_executable("${cjson_utils_test}" "${cjson_utils_test}.c")

--- a/tests/misc_tests.c
+++ b/tests/misc_tests.c
@@ -324,6 +324,92 @@ static void cjson_replace_item_in_object_should_preserve_name(void)
     cJSON_Delete(replacement);
 }
 
+static void cjson_functions_shouldnt_crash_with_null_pointers(void)
+{
+    char buffer[10];
+    cJSON *item = cJSON_CreateString("item");
+
+    cJSON_InitHooks(NULL);
+    TEST_ASSERT_NULL(cJSON_Parse(NULL));
+    TEST_ASSERT_NULL(cJSON_ParseWithOpts(NULL, NULL, true));
+    TEST_ASSERT_NULL(cJSON_Print(NULL));
+    TEST_ASSERT_NULL(cJSON_PrintUnformatted(NULL));
+    TEST_ASSERT_NULL(cJSON_PrintBuffered(NULL, 10, true));
+    TEST_ASSERT_FALSE(cJSON_PrintPreallocated(NULL, buffer, sizeof(buffer), true));
+    TEST_ASSERT_FALSE(cJSON_PrintPreallocated(item, NULL, 1, true));
+    cJSON_Delete(NULL);
+    cJSON_GetArraySize(NULL);
+    TEST_ASSERT_NULL(cJSON_GetArrayItem(NULL, 0));
+    TEST_ASSERT_NULL(cJSON_GetObjectItem(NULL, "item"));
+    TEST_ASSERT_NULL(cJSON_GetObjectItem(item, NULL));
+    TEST_ASSERT_NULL(cJSON_GetObjectItemCaseSensitive(NULL, "item"));
+    TEST_ASSERT_NULL(cJSON_GetObjectItemCaseSensitive(item, NULL));
+    TEST_ASSERT_FALSE(cJSON_HasObjectItem(NULL, "item"));
+    TEST_ASSERT_FALSE(cJSON_HasObjectItem(item, NULL));
+    TEST_ASSERT_FALSE(cJSON_IsInvalid(NULL));
+    TEST_ASSERT_FALSE(cJSON_IsFalse(NULL));
+    TEST_ASSERT_FALSE(cJSON_IsTrue(NULL));
+    TEST_ASSERT_FALSE(cJSON_IsBool(NULL));
+    TEST_ASSERT_FALSE(cJSON_IsNull(NULL));
+    TEST_ASSERT_FALSE(cJSON_IsNumber(NULL));
+    TEST_ASSERT_FALSE(cJSON_IsString(NULL));
+    TEST_ASSERT_FALSE(cJSON_IsArray(NULL));
+    TEST_ASSERT_FALSE(cJSON_IsObject(NULL));
+    TEST_ASSERT_FALSE(cJSON_IsRaw(NULL));
+    TEST_ASSERT_NULL(cJSON_CreateString(NULL));
+    TEST_ASSERT_NULL(cJSON_CreateRaw(NULL));
+    TEST_ASSERT_NULL(cJSON_CreateIntArray(NULL, 10));
+    TEST_ASSERT_NULL(cJSON_CreateFloatArray(NULL, 10));
+    TEST_ASSERT_NULL(cJSON_CreateDoubleArray(NULL, 10));
+    TEST_ASSERT_NULL(cJSON_CreateStringArray(NULL, 10));
+    cJSON_AddItemToArray(NULL, item);
+    cJSON_AddItemToArray(item, NULL);
+    cJSON_AddItemToObject(item, "item", NULL);
+    cJSON_AddItemToObject(item, NULL, item);
+    cJSON_AddItemToObject(NULL, "item", item);
+    cJSON_AddItemToObjectCS(item, "item", NULL);
+    cJSON_AddItemToObjectCS(item, NULL, item);
+    cJSON_AddItemToObjectCS(NULL, "item", item);
+    cJSON_AddItemReferenceToArray(NULL, item);
+    cJSON_AddItemReferenceToArray(item, NULL);
+    cJSON_AddItemReferenceToObject(item, "item", NULL);
+    cJSON_AddItemReferenceToObject(item, NULL, item);
+    cJSON_AddItemReferenceToObject(NULL, "item", item);
+    TEST_ASSERT_NULL(cJSON_DetachItemViaPointer(NULL, item));
+    TEST_ASSERT_NULL(cJSON_DetachItemViaPointer(item, NULL));
+    TEST_ASSERT_NULL(cJSON_DetachItemFromArray(NULL, 0));
+    cJSON_DeleteItemFromArray(NULL, 0);
+    TEST_ASSERT_NULL(cJSON_DetachItemFromObject(NULL, "item"));
+    TEST_ASSERT_NULL(cJSON_DetachItemFromObject(item, NULL));
+    TEST_ASSERT_NULL(cJSON_DetachItemFromObjectCaseSensitive(NULL, "item"));
+    TEST_ASSERT_NULL(cJSON_DetachItemFromObjectCaseSensitive(item, NULL));
+    cJSON_DeleteItemFromObject(NULL, "item");
+    cJSON_DeleteItemFromObject(item, NULL);
+    cJSON_DeleteItemFromObjectCaseSensitive(NULL, "item");
+    cJSON_DeleteItemFromObjectCaseSensitive(item, NULL);
+    cJSON_InsertItemInArray(NULL, 0, item);
+    cJSON_InsertItemInArray(item, 0, NULL);
+    TEST_ASSERT_FALSE(cJSON_ReplaceItemViaPointer(NULL, item, item));
+    TEST_ASSERT_FALSE(cJSON_ReplaceItemViaPointer(item, NULL, item));
+    TEST_ASSERT_FALSE(cJSON_ReplaceItemViaPointer(item, item, NULL));
+    cJSON_ReplaceItemInArray(item, 0, NULL);
+    cJSON_ReplaceItemInArray(NULL, 0, item);
+    cJSON_ReplaceItemInObject(NULL, "item", item);
+    cJSON_ReplaceItemInObject(item, NULL, item);
+    cJSON_ReplaceItemInObject(item, "item", NULL);
+    cJSON_ReplaceItemInObjectCaseSensitive(NULL, "item", item);
+    cJSON_ReplaceItemInObjectCaseSensitive(item, NULL, item);
+    cJSON_ReplaceItemInObjectCaseSensitive(item, "item", NULL);
+    TEST_ASSERT_NULL(cJSON_Duplicate(NULL, true));
+    TEST_ASSERT_FALSE(cJSON_Compare(item, NULL, false));
+    TEST_ASSERT_FALSE(cJSON_Compare(NULL, item, false));
+    cJSON_Minify(NULL);
+    /* skipped because it is only used via a macro that checks for NULL */
+    /* cJSON_SetNumberHelper(NULL, 0); */
+
+    cJSON_Delete(item);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -338,6 +424,7 @@ int main(void)
     RUN_TEST(cjson_detach_item_via_pointer_should_detach_items);
     RUN_TEST(cjson_replace_item_via_pointer_should_replace_items);
     RUN_TEST(cjson_replace_item_in_object_should_preserve_name);
+    RUN_TEST(cjson_functions_shouldnt_crash_with_null_pointers);
 
     return UNITY_END();
 }

--- a/tests/misc_utils_tests.c
+++ b/tests/misc_utils_tests.c
@@ -1,0 +1,80 @@
+/*
+  Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "unity/examples/unity_config.h"
+#include "unity/src/unity.h"
+#include "common.h"
+#include "../cJSON_Utils.h"
+
+static void cjson_utils_functions_shouldnt_crash_with_null_pointers(void)
+{
+    cJSON *item = cJSON_CreateString("item");
+    TEST_ASSERT_NOT_NULL(item);
+
+    TEST_ASSERT_NULL(cJSONUtils_GetPointer(item, NULL));
+    TEST_ASSERT_NULL(cJSONUtils_GetPointer(NULL, "pointer"));
+    TEST_ASSERT_NULL(cJSONUtils_GetPointerCaseSensitive(NULL, "pointer"));
+    TEST_ASSERT_NULL(cJSONUtils_GetPointerCaseSensitive(item, NULL));
+    TEST_ASSERT_NULL(cJSONUtils_GeneratePatches(item, NULL));
+    TEST_ASSERT_NULL(cJSONUtils_GeneratePatches(NULL, item));
+    TEST_ASSERT_NULL(cJSONUtils_GeneratePatchesCaseSensitive(item, NULL));
+    TEST_ASSERT_NULL(cJSONUtils_GeneratePatchesCaseSensitive(NULL, item));
+    cJSONUtils_AddPatchToArray(item, "path", "add", NULL);
+    cJSONUtils_AddPatchToArray(item, "path", NULL, item);
+    cJSONUtils_AddPatchToArray(item, NULL, "add", item);
+    cJSONUtils_AddPatchToArray(NULL, "path", "add", item);
+    cJSONUtils_ApplyPatches(item, NULL);
+    cJSONUtils_ApplyPatches(NULL, item);
+    cJSONUtils_ApplyPatchesCaseSensitive(item, NULL);
+    cJSONUtils_ApplyPatchesCaseSensitive(NULL, item);
+    TEST_ASSERT_NULL(cJSONUtils_MergePatch(item, NULL));
+    item = cJSON_CreateString("item");
+    TEST_ASSERT_NULL(cJSONUtils_MergePatchCaseSensitive(item, NULL));
+    item = cJSON_CreateString("item");
+    /* these calls are actually valid */
+    /* cJSONUtils_MergePatch(NULL, item); */
+    /* cJSONUtils_MergePatchCaseSensitive(NULL, item);*/
+    /* cJSONUtils_GenerateMergePatch(item, NULL); */
+    /* cJSONUtils_GenerateMergePatch(NULL, item); */
+    /* cJSONUtils_GenerateMergePatchCaseSensitive(item, NULL); */
+    /* cJSONUtils_GenerateMergePatchCaseSensitive(NULL, item); */
+
+    TEST_ASSERT_NULL(cJSONUtils_FindPointerFromObjectTo(item, NULL));
+    TEST_ASSERT_NULL(cJSONUtils_FindPointerFromObjectTo(NULL, item));
+    cJSONUtils_SortObject(NULL);
+    cJSONUtils_SortObjectCaseSensitive(NULL);
+
+    cJSON_Delete(item);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(cjson_utils_functions_shouldnt_crash_with_null_pointers);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
This fixes a lot of potential null pointer dereferences and some memory leaks.

My search for NULL pointer dereferences was triggered by #182.

I wrote a test bench to test almost all functions with NULL pointers as inputs, but stupid me accidentally deleted it, so I'm gonna have to do that from scratch ...

- [x] test cJSON functions with NULL parameters
- [x] fix NULL pointer dereferences in cJSON
- [x] test cJSON_Utils functions with NULL parameters
- [x] fix NULL pointer dereferences in cJSON_Utils