### PR TITLE
libcjson.pc error in yocto environment

### DIFF
--- a/library_config/libcjson.pc.in
+++ b/library_config/libcjson.pc.in
@@ -1,6 +1,6 @@
-prefix=@prefix@
-libdir=${prefix}/@libdir@
-includedir=${prefix}/@includedir@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
 
 Name: libcjson
 Version: @version@

--- a/library_config/libcjson.pc.in
+++ b/library_config/libcjson.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${prefix}/lib
-includedir=${prefix}/include
+includedir=${prefix}/include/cjson
 
 Name: libcjson
 Version: @version@


### PR DESCRIPTION
In the yocto environment(http://www.yoctoproject.org/), the bitbake will add parameters automotively like below:

          -DCMAKE_INSTALL_PREFIX:PATH=/usr \
          -DCMAKE_INSTALL_BINDIR:PATH=/usr/bin \
          -DCMAKE_INSTALL_SBINDIR:PATH=/usr/sbin \
          -DCMAKE_INSTALL_LIBEXECDIR:PATH=/usr/lib/cjson-davegamble \
          -DCMAKE_INSTALL_SYSCONFDIR:PATH=/etc \
          -DCMAKE_INSTALL_SHAREDSTATEDIR:PATH=/com \
          -DCMAKE_INSTALL_LOCALSTATEDIR:PATH=/var \
          -DCMAKE_INSTALL_LIBDIR:PATH=/usr/lib \
          -DCMAKE_INSTALL_INCLUDEDIR:PATH=/usr/include \
          -DCMAKE_INSTALL_DATAROOTDIR:PATH=/usr/share \

and this will make mistake in the pc-file.