### PR TITLE
if end pointer non null, assumes end of string

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -1013,7 +1013,11 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return
     }
 
     buffer.content = (const unsigned char*)value;
-    buffer.length = strlen((const char*)value) + sizeof("");
+    if(return_parse_end && *return_parse_end){
+        buffer.length = (size_t)(*return_parse_end - value);
+    }else{
+        buffer.length = strlen((const char*)value) + sizeof("");
+    }
     buffer.offset = 0;
     buffer.hooks = global_hooks;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ if(ENABLE_CJSON_TEST)
     set(unity_tests
         parse_examples
         parse_number
+        parse_memory
         parse_hex4
         parse_string
         parse_array

--- a/tests/parse_memory.c
+++ b/tests/parse_memory.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+#include "unity/examples/unity_config.h"
+#include "unity/src/unity.h"
+
+static void parse_memory_should_parse_true(void) {
+    cJSON *item;
+    const char *mem =
+                   "{"
+                   "\"hello\":\"world\""
+                   "}",
+               *end = mem + strlen(mem);
+    item = cJSON_ParseWithOpts(mem, &end, false);
+    TEST_ASSERT_NOT_NULL(item);
+    cJSON_Delete(item);
+}
+
+int main(void) {
+    /* initialize cJSON item */
+    UNITY_BEGIN();
+    RUN_TEST(parse_memory_should_parse_true);
+    return UNITY_END();
+}


### PR DESCRIPTION
Hello,

This modifies parse with opts so that if the return end pointer is pointing than that is the end of the string so as to not use strlen.  Was not sure of other method to parse something that is not a string.  I added small test case.

Could not find a method to parse "memory" as opposed to parse string.