### PR TITLE
json patch: adding to a subfield of a non-object now fails as expected

### DIFF
--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -988,6 +988,12 @@ static int apply_patch(cJSON *object, const cJSON *patch, const cJSON_bool case_
         cJSON_AddItemToObject(parent, (char*)child_pointer, value);
         value = NULL;
     }
+    else /* parent is not an object */
+    {
+        /* Couldn't find object to add to. */
+        status = 9;
+        goto cleanup;
+    }
 
 cleanup:
     if (value != NULL)

--- a/tests/json-patch-tests/cjson-utils-tests.json
+++ b/tests/json-patch-tests/cjson-utils-tests.json
@@ -80,5 +80,12 @@
 	"doc": { "foo": ["bar"] },
 	"patch": [ { "op": "add", "path": "/foo/-", "value": ["abc", "def"] }],
 	"expected": {"foo": ["bar", ["abc", "def"]] }
-    }
+    },
+
+    { 
+        "comment": "15",
+        "doc": {"foo": {"bar": 1}},
+        "patch": [{"op": "add", "path": "/foo/bar/baz", "value": "5"}],
+        "error": "attempting to add to subfield of non-object"
+    } 
 ]


### PR DESCRIPTION
This fixes a non-compliance with the json patch standard