### PR TITLE
Introduces cJSON_ParseWithLen().

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -997,7 +997,7 @@ static parse_buffer *skip_utf8_bom(parse_buffer * const buffer)
 }
 
 /* Parse an object - create a new root, and populate. */
-CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated)
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLen(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated, size_t value_len)
 {
     parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
     cJSON *item = NULL;
@@ -1012,7 +1012,7 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return
     }
 
     buffer.content = (const unsigned char*)value;
-    buffer.length = strlen((const char*)value) + sizeof("");
+    buffer.length = value_len;
     buffer.offset = 0;
     buffer.hooks = global_hooks;
 
@@ -1074,6 +1074,11 @@ fail:
     }
 
     return NULL;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated)
+{
+    return cJSON_ParseWithLen(value, return_parse_end, require_null_terminated, strlen(value) + 1);
 }
 
 /* Default options for cJSON_Parse */

--- a/cJSON.h
+++ b/cJSON.h
@@ -141,6 +141,9 @@ CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value);
 /* ParseWithOpts allows you to require (and check) that the JSON is null terminated, and to retrieve the pointer to the final byte parsed. */
 /* If you supply a ptr in return_parse_end and parsing fails, then return_parse_end will contain a pointer to the error so will match cJSON_GetErrorPtr(). */
 CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated);
+/* ParseWithLen is like ParseWithOpts, but allows a length of the value to supplied so that it need not be null terminated. */
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLen(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated, size_t value_len);
+
 
 /* Render a cJSON entity to text for transfer/storage. */
 CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item);


### PR DESCRIPTION
This new cJSON_ParseWithLen() behaves very much like the
cJSON_ParseWithOptions() function, but adds a length parameter.
The WithOptions() call is refactored to call WithLen(), passing
the length strlen()+1.  (+1 is actually more pedantically correct,
since we're explicitly counting the NUL byte rather than the
length of an empty string.  Even more pedantic would have been
sizeof ('\0').  At any rate the constant is better than strlen().

I'm using this function in my code where I have binary message
containing JSON, which is generally length delimited rather than
NUL terminated.  I pass the message length, and false for the
require_null_terminated flag, and it seems to work well.

This address part of #57 