### PR TITLE
fix: implicit conversion to double promotion compile warning

### DIFF
--- a/tests/unity/src/unity.c
+++ b/tests/unity/src/unity.c
@@ -268,14 +268,14 @@ void UnityPrintFloat(const UNITY_DOUBLE input_number)
     UNITY_DOUBLE number = input_number;
 
     /* print minus sign (including for negative zero) */
-    if (number < 0.0f || (number == 0.0f && 1.0f / number < 0.0f))
+    if (number < 0.0 || (number == 0.0 && 1.0 / number < 0.0))
     {
         UNITY_OUTPUT_CHAR('-');
         number = -number;
     }
 
     /* handle zero, NaN, and +/- infinity */
-    if (number == 0.0f) UnityPrint("0");
+    if (number == 0.0) UnityPrint("0");
     else if (isnan(number)) UnityPrint("nan");
     else if (isinf(number)) UnityPrint("inf");
     else
@@ -286,10 +286,10 @@ void UnityPrintFloat(const UNITY_DOUBLE input_number)
         char buf[16];
 
         /* scale up or down by powers of 10 */
-        while (number < 100000.0f / 1e6f)  { number *= 1e6f; exponent -= 6; }
-        while (number < 100000.0f)         { number *= 10.0f; exponent--; }
-        while (number > 1000000.0f * 1e6f) { number /= 1e6f; exponent += 6; }
-        while (number > 1000000.0f)        { number /= 10.0f; exponent++; }
+        while (number < 100000.0 / 1e6)  { number *= 1e6; exponent -= 6; }
+        while (number < 100000.0)         { number *= 10.0; exponent--; }
+        while (number > 1000000.0 * 1e6) { number /= 1e6; exponent += 6; }
+        while (number > 1000000.0)        { number /= 10.0; exponent++; }
 
         /* round to nearest integer */
         n = ((UNITY_INT32)(number + number) + 1) / 2;


### PR DESCRIPTION
### PROBLEM
```
[ 12%] Building C object tests/CMakeFiles/unity.dir/unity/src/unity.c.o
/Users/pkumar12/Code/GitHub/cJSON/tests/unity/src/unity.c:271:18: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    if (number < 0.0f || (number == 0.0f && 1.0f / number < 0.0f))
               ~ ^~~~
/Users/pkumar12/Code/GitHub/cJSON/tests/unity/src/unity.c:271:37: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    if (number < 0.0f || (number == 0.0f && 1.0f / number < 0.0f))
                                 ~~ ^~~~
/Users/pkumar12/Code/GitHub/cJSON/tests/unity/src/unity.c:271:45: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    if (number < 0.0f || (number == 0.0f && 1.0f / number < 0.0f))
                                            ^~~~ ~
/Users/pkumar12/Code/GitHub/cJSON/tests/unity/src/unity.c:271:61: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    if (number < 0.0f || (number == 0.0f && 1.0f / number < 0.0f))
                                                          ~ ^~~~
/Users/pkumar12/Code/GitHub/cJSON/tests/unity/src/unity.c:278:19: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
    if (number == 0.0f) UnityPrint("0");
               ~~ ^~~~
/Users/pkumar12/Code/GitHub/cJSON/tests/unity/src/unity.c:289:35: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
        while (number < 100000.0f / 1e6f)  { number *= 1e6f; exponent -= 6; }
                      ~ ~~~~~~~~~~^~~~~~
/Users/pkumar12/Code/GitHub/cJSON/tests/unity/src/unity.c:289:56: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
        while (number < 100000.0f / 1e6f)  { number *= 1e6f; exponent -= 6; }
                                                    ~~ ^~~~
/Users/pkumar12/Code/GitHub/cJSON/tests/unity/src/unity.c:290:25: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
        while (number < 100000.0f)         { number *= 10.0f; exponent--; }
                      ~ ^~~~~~~~~
/Users/pkumar12/Code/GitHub/cJSON/tests/unity/src/unity.c:290:56: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
        while (number < 100000.0f)         { number *= 10.0f; exponent--; }
                                                    ~~ ^~~~~
/Users/pkumar12/Code/GitHub/cJSON/tests/unity/src/unity.c:291:36: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
        while (number > 1000000.0f * 1e6f) { number /= 1e6f; exponent += 6; }
                      ~ ~~~~~~~~~~~^~~~~~
/Users/pkumar12/Code/GitHub/cJSON/tests/unity/src/unity.c:291:56: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
        while (number > 1000000.0f * 1e6f) { number /= 1e6f; exponent += 6; }
                                                    ~~ ^~~~
/Users/pkumar12/Code/GitHub/cJSON/tests/unity/src/unity.c:292:25: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
        while (number > 1000000.0f)        { number /= 10.0f; exponent++; }
                      ~ ^~~~~~~~~~
/Users/pkumar12/Code/GitHub/cJSON/tests/unity/src/unity.c:292:56: warning: implicit conversion increases floating-point precision: 'float' to 'double' [-Wdouble-promotion]
        while (number > 1000000.0f)        { number /= 10.0f; exponent++; }
                                                    ~~ ^~~~~
13 warnings generated.
```

### SOLUTION
As per documentation, in 'C', "**The type of a floating literal is double unless explicitly specified by a suffix**" Hence removed the 'suffices' from all the warning lines.
Also, the type of the variable number is 'double' so removing the suffices seem to make sense.

