### PR TITLE
Tightly pack the cJSON struct

### DIFF
--- a/cJSON.h
+++ b/cJSON.h
@@ -111,10 +111,10 @@ typedef struct cJSON
     /* The type of the item, as above. */
     int type;
 
-    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
-    char *valuestring;
     /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
     int valueint;
+    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
+    char *valuestring;
     /* The item's number, if type==cJSON_Number */
     double valuedouble;
 

--- a/tests/misc_tests.c
+++ b/tests/misc_tests.c
@@ -199,7 +199,7 @@ static void cjson_should_not_parse_to_deeply_nested_jsons(void)
 
 static void cjson_set_number_value_should_set_numbers(void)
 {
-    cJSON number[1] = {{NULL, NULL, NULL, cJSON_Number, NULL, 0, 0, NULL}};
+    cJSON number[1] = {{NULL, NULL, NULL, cJSON_Number, 0, NULL, 0, NULL}};
 
     cJSON_SetNumberValue(number, 1.5);
     TEST_ASSERT_EQUAL(1, number->valueint);
@@ -306,7 +306,7 @@ static void cjson_replace_item_via_pointer_should_replace_items(void)
 
 static void cjson_replace_item_in_object_should_preserve_name(void)
 {
-    cJSON root[1] = {{ NULL, NULL, NULL, 0, NULL, 0, 0, NULL }};
+    cJSON root[1] = {{ NULL, NULL, NULL, 0, 0, NULL, 0, NULL }};
     cJSON *child = NULL;
     cJSON *replacement = NULL;
 


### PR DESCRIPTION
Running pahole(https://linux.die.net/man/1/pahole) flags cJSON as a
packable struct on x86-64.

This patch moves the members of type 'int' next to each other and plugs
the two 4-bytes holes. This reduces the struct size from 64-bytes to
56-bytes.
see https://godbolt.org/z/gUr5ue

I understand that this breaks the ABI. So, probably a version bump is due.