### PR TITLE
fix bug: sort_list() returns strange results

### DIFF
--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -510,7 +510,7 @@ static cJSON *sort_list(cJSON *list, const cJSON_bool case_sensitive)
     while ((first != NULL) && (second != NULL))
     {
         cJSON *smaller = NULL;
-        if (compare_strings((unsigned char*)first->string, (unsigned char*)second->string, false) < 0)
+        if (compare_strings((unsigned char*)first->string, (unsigned char*)second->string, case_sensitive) < 0)
         {
             smaller = first;
         }


### PR DESCRIPTION
sort_list() returns strange results when the 2nd parameter is true.