### PR TITLE
allow to override PIC_FLAGS and compiler std

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ INSTALL_LIBRARY_PATH = $(DESTDIR)$(PREFIX)/$(LIBRARY_PATH)
 
 INSTALL ?= cp -a
 
+CC = gcc -std=c89
+
 # validate gcc version for use fstack-protector-strong
 MIN_GCC_VERSION = "4.9"
 GCC_VERSION := "`$(CC) -dumpversion`"
@@ -34,7 +36,8 @@ else
     CFLAGS += -fstack-protector
 endif
 
-R_CFLAGS = -fPIC -std=c89 -pedantic -Wall -Werror -Wstrict-prototypes -Wwrite-strings -Wshadow -Winit-self -Wcast-align -Wformat=2 -Wmissing-prototypes -Wstrict-overflow=2 -Wcast-qual -Wc++-compat -Wundef -Wswitch-default -Wconversion $(CFLAGS)
+PIC_FLAGS = -fPIC
+R_CFLAGS = $(PIC_FLAGS) -pedantic -Wall -Werror -Wstrict-prototypes -Wwrite-strings -Wshadow -Winit-self -Wcast-align -Wformat=2 -Wmissing-prototypes -Wstrict-overflow=2 -Wcast-qual -Wc++-compat -Wundef -Wswitch-default -Wconversion $(CFLAGS)
 
 uname := $(shell sh -c 'uname -s 2>/dev/null || echo false')
 


### PR DESCRIPTION
PIC_FLAGS: different environment need different options here (or cannot have `-fPIC`), the proposed change make it easy to only override (and possibly remove) this option.
CC: according to the GNU make docs it is a good practice to have the std in `CC`, not in `CFLAGS`, just did this as I see no reason to not do it.
