### PR TITLE
Add a comment to the parameter count of the cJSON_CreateIntArray function

### DIFF
--- a/cJSON.h
+++ b/cJSON.h
@@ -208,7 +208,8 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateStringReference(const char *string);
 CJSON_PUBLIC(cJSON *) cJSON_CreateObjectReference(const cJSON *child);
 CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child);
 
-/* These utilities create an Array of count items. */
+/* These utilities create an Array of count items. *
+*The parameter count cannot be greater than the number of elements in the number array,otherwise array access will be out of bounds.*/
 CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count);
 CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count);
 CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count);

--- a/cJSON.h
+++ b/cJSON.h
@@ -208,8 +208,8 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateStringReference(const char *string);
 CJSON_PUBLIC(cJSON *) cJSON_CreateObjectReference(const cJSON *child);
 CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child);
 
-/* These utilities create an Array of count items. *
-*The parameter count cannot be greater than the number of elements in the number array,otherwise array access will be out of bounds.*/
+/* These utilities create an Array of count items.
+ * The parameter count cannot be greater than the number of elements in the number array, otherwise array access will be out of bounds.*/
 CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count);
 CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count);
 CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count);


### PR DESCRIPTION
I used cJSON_CreateIntArray to create a jSON array. Since conut is greater than the array, the array access is out of bounds, so I submitted a comment.