### PR TITLE
fix bug: add const to the parameter in the cJSON_GetStringValue function

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -79,7 +79,7 @@ CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void)
     return (const char*) (global_error.json + global_error.position);
 }
 
-CJSON_PUBLIC(char *) cJSON_GetStringValue(cJSON *item) {
+CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item) {
     if (!cJSON_IsString(item)) {
         return NULL;
     }

--- a/cJSON.h
+++ b/cJSON.h
@@ -174,7 +174,7 @@ CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *st
 CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void);
 
 /* Check if the item is a string and return its valuestring */
-CJSON_PUBLIC(char *) cJSON_GetStringValue(cJSON *item);
+CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item);
 
 /* These functions check the type of an item */
 CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON * const item);


### PR DESCRIPTION
As mentioned in issue #376,if the defined cJSON object is a constant,after passing it to the cJSON_GetStringValue function,there will be a const cast warning when compiling the program.
```
int main(void)
{
    char *result;
    const char *string = "\"Hello world\"";
    const cJSON * const json = cJSON_Parse(string);
    result = cJSON_GetStringValue(json);
    printf("result=%s\n",result);
}
```