### PR TITLE
Add libFuzzer fuzz target / OSS-Fuzz integration

### DIFF
--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -28,6 +28,6 @@ if (ENABLE_FUZZING)
 endif()
 
 if(ENABLE_CJSON_TEST)
-    ADD_EXECUTABLE(fuzz_main fuzz_main.c)
+    ADD_EXECUTABLE(fuzz_main fuzz_main.c cjson_read_fuzzer.c)
     TARGET_LINK_LIBRARIES(fuzz_main cjson)
 endif()

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -26,3 +26,8 @@ if (ENABLE_FUZZING)
 
 
 endif()
+
+if(ENABLE_CJSON_TEST)
+    ADD_EXECUTABLE(fuzz_main fuzz_main.c)
+    TARGET_LINK_LIBRARIES(fuzz_main cjson)
+endif()

--- a/fuzzing/cjson_read_fuzzer.cc
+++ b/fuzzing/cjson_read_fuzzer.cc
@@ -8,7 +8,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     size_t offset = 4;
 
-    if(size < offset) return 0;
+    if(size <= offset) return 0;
     if(data[0] != '1' && data[0] != '0') return 0;
     if(data[1] != '1' && data[1] != '0') return 0;
     if(data[2] != '1' && data[2] != '0') return 0;

--- a/fuzzing/cjson_read_fuzzer.cc
+++ b/fuzzing/cjson_read_fuzzer.cc
@@ -1,0 +1,41 @@
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "../cJSON.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    if((data[0] == '\0') || (size < 3) || (data[1] == '\0')) return 0;
+
+    cJSON *json = cJSON_Parse((const char*)data + 2);
+
+    if(json == NULL) return 0;
+
+    int do_format = 0;
+    char *printed_json = NULL;
+
+    if(data[1] == 'f') do_format = 1;
+
+    if(data[0] == 'b')
+    {
+        /* buffered printing */
+        printed_json = cJSON_PrintBuffered(json, 1, do_format);
+    }
+    else
+    {
+        /* unbuffered printing */
+        if(do_format)
+        {
+            printed_json = cJSON_Print(json);
+        }
+        else
+        {
+            printed_json = cJSON_PrintUnformatted(json);
+        }
+    }
+
+    if(printed_json != NULL) free(printed_json);
+    cJSON_Delete(json);
+
+    return 0;
+}

--- a/fuzzing/cjson_read_fuzzer.cc
+++ b/fuzzing/cjson_read_fuzzer.cc
@@ -1,30 +1,38 @@
 #include <stdlib.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "../cJSON.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    if((data[0] == '\0') || (size < 3) || (data[1] == '\0')) return 0;
+    size_t offset = 4;
 
-    cJSON *json = cJSON_Parse((const char*)data + 2);
+    if(size < offset) return 0;
+    if(data[0] != '1' && data[0] != '0') return 0;
+    if(data[1] != '1' && data[1] != '0') return 0;
+    if(data[2] != '1' && data[2] != '0') return 0;
+    if(data[3] != '1' && data[3] != '0') return 0;
+
+    int minify              = data[0] == '1' ? 1 : 0;
+    int require_termination = data[1] == '1' ? 1 : 0;
+    int formatted           = data[2] == '1' ? 1 : 0;
+    int buffered            = data[3] == '1' ? 1 : 0;
+
+    cJSON *json = cJSON_ParseWithOpts((const char*)data + offset, NULL, require_termination);
 
     if(json == NULL) return 0;
 
-    int do_format = 0;
     char *printed_json = NULL;
 
-    if(data[1] == 'f') do_format = 1;
-
-    if(data[0] == 'b')
+    if(buffered)
     {
-        /* buffered printing */
-        printed_json = cJSON_PrintBuffered(json, 1, do_format);
+        printed_json = cJSON_PrintBuffered(json, 1, formatted);
     }
     else
     {
         /* unbuffered printing */
-        if(do_format)
+        if(formatted)
         {
             printed_json = cJSON_Print(json);
         }
@@ -35,6 +43,18 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     }
 
     if(printed_json != NULL) free(printed_json);
+
+    if(minify)
+    {
+        unsigned char *copied = (unsigned char*)malloc(size);
+
+        memcpy(copied, data + offset, size);
+
+        cJSON_Minify((char*)printed_json);
+        free(copied);
+    }
+
+    
     cJSON_Delete(json);
 
     return 0;

--- a/fuzzing/cjson_read_fuzzer.cc
+++ b/fuzzing/cjson_read_fuzzer.cc
@@ -4,9 +4,17 @@
 
 #include "../cJSON.h"
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+#ifdef __cplusplus
+extern "C"
+#endif
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
+    cJSON *json;
     size_t offset = 4;
+    unsigned char *copied;
+    char *printed_json = NULL;
+    int minify, require_termination, formatted, buffered;
+
 
     if(size <= offset) return 0;
     if(data[0] != '1' && data[0] != '0') return 0;
@@ -14,26 +22,24 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     if(data[2] != '1' && data[2] != '0') return 0;
     if(data[3] != '1' && data[3] != '0') return 0;
 
-    int minify              = data[0] == '1' ? 1 : 0;
-    int require_termination = data[1] == '1' ? 1 : 0;
-    int formatted           = data[2] == '1' ? 1 : 0;
-    int buffered            = data[3] == '1' ? 1 : 0;
+    minify              = data[0] == '1' ? 1 : 0;
+    require_termination = data[1] == '1' ? 1 : 0;
+    formatted           = data[2] == '1' ? 1 : 0;
+    buffered            = data[3] == '1' ? 1 : 0;
 
-    unsigned char *copied = (unsigned char*)malloc(size);
+    copied = (unsigned char*)malloc(size);
     if(copied == NULL) return 0;
 
     memcpy(copied, data, size);
     copied[size-1] = '\0';
 
-    cJSON *json = cJSON_ParseWithOpts((const char*)copied + offset, NULL, require_termination);
+    json = cJSON_ParseWithOpts((const char*)copied + offset, NULL, require_termination);
 
     if(json == NULL)
     {
         free(copied);
         return 0;
     }
-
-    char *printed_json = NULL;
 
     if(buffered)
     {

--- a/fuzzing/fuzz_main.c
+++ b/fuzzing/fuzz_main.c
@@ -1,0 +1,56 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size); /* required by C90 */
+
+#include "cjson_read_fuzzer.cc"
+
+/* fuzz target entry point, works without libFuzzer */
+
+int main(int argc, char **argv)
+{
+    FILE *f;
+    char *buf = NULL;
+    long siz_buf;
+
+    if(argc < 2)
+    {
+        fprintf(stderr, "no input file\n");
+        goto err;
+    }
+
+    f = fopen(argv[1], "rb");
+    if(f == NULL)
+    {
+        fprintf(stderr, "error opening input file %s\n", argv[1]);
+        goto err;
+    }
+
+    fseek(f, 0, SEEK_END);
+
+    siz_buf = ftell(f);
+    rewind(f);
+
+    if(siz_buf < 1) goto err;
+
+    buf = (char*)malloc((size_t)siz_buf);
+    if(buf == NULL)
+    {
+        fprintf(stderr, "malloc() failed\n");
+        goto err;
+    }
+
+    if(fread(buf, (size_t)siz_buf, 1, f) != 1)
+    {
+        fprintf(stderr, "fread() failed\n");
+        goto err;
+    }
+
+    (void)LLVMFuzzerTestOneInput((uint8_t*)buf, (size_t)siz_buf);
+
+err:
+    free(buf);
+
+    return 0;
+}

--- a/fuzzing/fuzz_main.c
+++ b/fuzzing/fuzz_main.c
@@ -2,9 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size); /* required by C90 */
-
-#include "cjson_read_fuzzer.cc"
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size); /* required by C89 */
 
 /* fuzz target entry point, works without libFuzzer */
 

--- a/fuzzing/ossfuzz.sh
+++ b/fuzzing/ossfuzz.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+
+# This script is meant to be run by
+# https://github.com/google/oss-fuzz/blob/master/projects/cjson/Dockerfile
+
+mkdir build
+cd build
+cmake -DBUILD_SHARED_LIBS=OFF -DENABLE_CJSON_TEST=OFF ..
+make -j$(nproc)
+
+$CXX $CXXFLAGS -std=c++11 -I. \
+    $SRC/cjson/fuzzing/cjson_read_fuzzer.cc \
+    -o $OUT/cjson_read_fuzzer \
+    $LIB_FUZZING_ENGINE $SRC/cjson/build/libcjson.a
+
+find $SRC/cjson/fuzzing/inputs -name "*" | \
+     xargs zip $OUT/cjson_read_fuzzer_seed_corpus.zip
+
+cp $SRC/cjson/fuzzing/json.dict $OUT/cjson_read_fuzzer.dict

--- a/fuzzing/ossfuzz.sh
+++ b/fuzzing/ossfuzz.sh
@@ -8,8 +8,8 @@ cd build
 cmake -DBUILD_SHARED_LIBS=OFF -DENABLE_CJSON_TEST=OFF ..
 make -j$(nproc)
 
-$CXX $CXXFLAGS -std=c++11 -I. \
-    $SRC/cjson/fuzzing/cjson_read_fuzzer.cc \
+$CC $CFLAGS -std=c89 -I. \
+    $SRC/cjson/fuzzing/cjson_read_fuzzer.c \
     -o $OUT/cjson_read_fuzzer \
     $LIB_FUZZING_ENGINE $SRC/cjson/build/libcjson.a
 


### PR DESCRIPTION
This PR adds a libFuzzer fuzz target that works with [OSS-Fuzz](https://github.com/randy408/oss-fuzz/tree/cjson).

edit: Added a fuzz driver which doesn't require libFuzzer, it's built when testing is enabled.