### PR TITLE
Fixed 1 missing dependency in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ $(UTILS_SHARED_VERSION): $(UTILS_OBJ)
 #cJSON
 $(CJSON_OBJ): cJSON.c cJSON.h
 #cJSON_Utils
-$(UTILS_OBJ): cJSON_Utils.c cJSON_Utils.h
+$(UTILS_OBJ): cJSON_Utils.c cJSON_Utils.h cJSON.h
 
 
 #links .so -> .so.1 -> .so.1.0.0


### PR DESCRIPTION
Hi, I've fixed 1 missing dependency reported.
This issue can cause incorrect results when cJSON is incrementally built. Any changes in "cJSON.h" will not cause "cJSON_Utils.o" to be rebuilt, which is incorrect.
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

Thanks
Vemake