### PR TITLE
fix rmdir error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,9 +141,8 @@ uninstall-cjson: uninstall-utils
 	$(RM) $(INSTALL_LIBRARY_PATH)/$(CJSON_SHARED)
 	$(RM) $(INSTALL_LIBRARY_PATH)/$(CJSON_SHARED_VERSION)
 	$(RM) $(INSTALL_LIBRARY_PATH)/$(CJSON_SHARED_SO)
-	rmdir $(INSTALL_LIBRARY_PATH)
 	$(RM) $(INSTALL_INCLUDE_PATH)/cJSON.h
-	rmdir $(INSTALL_INCLUDE_PATH)
+	
 #cJSON_Utils
 uninstall-utils:
 	$(RM) $(INSTALL_LIBRARY_PATH)/$(UTILS_SHARED)
@@ -151,7 +150,11 @@ uninstall-utils:
 	$(RM) $(INSTALL_LIBRARY_PATH)/$(UTILS_SHARED_SO)
 	$(RM) $(INSTALL_INCLUDE_PATH)/cJSON_Utils.h
 
-uninstall: uninstall-utils uninstall-cjson
+remove-dir:
+	$(if $(wildcard $(INSTALL_LIBRARY_PATH)/*.*),,rmdir $(INSTALL_LIBRARY_PATH))
+	$(if $(wildcard $(INSTALL_INCLUDE_PATH)/*.*),,rmdir $(INSTALL_INCLUDE_PATH))
+
+uninstall: uninstall-utils uninstall-cjson remove-dir
 
 clean:
 	$(RM) $(CJSON_OBJ) $(UTILS_OBJ) #delete object files

--- a/cJSON.h
+++ b/cJSON.h
@@ -244,14 +244,14 @@ CJSON_PUBLIC(void) cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object,const ch
 /* Duplicate a cJSON item */
 CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse);
 /* Duplicate will create a new, identical cJSON item to the one you pass, in new memory that will
-need to be released. With recurse!=0, it will duplicate any children connected to the item.
-The item->next and ->prev pointers are always zero on return from Duplicate. */
+ * need to be released. With recurse!=0, it will duplicate any children connected to the item.
+ * The item->next and ->prev pointers are always zero on return from Duplicate. */
 /* Recursively compare two cJSON items for equality. If either a or b is NULL or invalid, they will be considered unequal.
  * case_sensitive determines if object keys are treated case sensitive (1) or case insensitive (0) */
 CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive);
 
-/* Minify a strings, remove blank characters(such as ' ', '\t', '\r', '\n') from strings */
-/* The input pointer json cannot point to a read-only address area, such as a string constant, 
+/* Minify a strings, remove blank characters(such as ' ', '\t', '\r', '\n') from strings.
+ * The input pointer json cannot point to a read-only address area, such as a string constant, 
  * but should point to a readable and writable adress area. */
 CJSON_PUBLIC(void) cJSON_Minify(char *json);
 


### PR DESCRIPTION
The default directory of `INSTALL_LIBRARY_PATH` is `/usr/local/lib`, usually this dir is not empty, so it will report an error when execute command `make uninstall`. Adding a test whether the dir is empty could avoid the error.
```
rmdir /usr/local/lib
rmdir: failed to remove '/usr/local/lib': Directory not empty
```