### PR TITLE
CMake: add uninstall target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,9 @@ if(ENABLE_CJSON_TEST)
         DEPENDS ${TEST_CJSON})
 endif()
 
+#Create the uninstall target
+add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${PROJECT_SOURCE_DIR}/library_config/uninstall.cmake")
+
 # Enable the use of locales
 option(ENABLE_LOCALES "Enable the use of locales" ON)
 if(ENABLE_LOCALES)

--- a/library_config/uninstall.cmake
+++ b/library_config/uninstall.cmake
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 2.8.5)
+
+set(MANIFEST "${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt")
+
+if(NOT EXISTS ${MANIFEST})
+    message(FATAL_ERROR "Cannot find install mainfest: ${MANIFEST}")
+endif()
+
+file(STRINGS ${MANIFEST} files)
+foreach(file ${files})
+    if(EXISTS ${file} OR IS_SYMLINK ${file})
+        message(STATUS "Removing: ${file}")
+
+	execute_process(COMMAND rm -f ${file}
+            RESULT_VARIABLE result
+            OUTPUT_QUIET
+            ERROR_VARIABLE stderr
+            ERROR_STRIP_TRAILING_WHITESPACE
+        )
+
+        if(NOT ${result} EQUAL 0)
+            message(FATAL_ERROR "${stderr}")
+        endif()
+    else()
+        message(STATUS "Does-not-exist: ${file}")
+    endif()
+endforeach(file)


### PR DESCRIPTION
Adding uninstall target for easily removing all of the installed files.  
Remove targets by `make uninstall`.