### PR TITLE
Update cJSON_Utils.c to avoid ‘CJSON_DOUBLE_PRECIION’ undeclared

### DIFF
--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -109,7 +109,7 @@ static int compare_strings(const unsigned char *string1, const unsigned char *st
 /* securely comparison of floating-point variables */
 static cJSON_bool compare_double(double a, double b)
 {
-    return (fabs(a - b) <= a * CJSON_DOUBLE_PRECIION);
+    return (fabs(a - b) <= a * CJSON_DOUBLE_PRECISION);
 }
 
 


### PR DESCRIPTION
fix typo