### PR TITLE
Add long values support 

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -333,10 +333,12 @@ loop_end:
     if (number >= INT_MAX)
     {
         item->valueint = INT_MAX;
+        item->valuelong = (long)strtol((const char *)number_c_string, (char **)NULL, 10);
     }
     else if (number <= (double)INT_MIN)
     {
         item->valueint = INT_MIN;
+        item->valuelong = (long)strtol((const char *)number_c_string, (char **)NULL, 10);
     }
     else
     {

--- a/cJSON.h
+++ b/cJSON.h
@@ -115,6 +115,7 @@ typedef struct cJSON
     char *valuestring;
     /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
     int valueint;
+    long valuelong;
     /* The item's number, if type==cJSON_Number */
     double valuedouble;
 


### PR DESCRIPTION
During working with Telegram Bot API with cJSON library for parsing values, I've faced an issue. The issue is this: I was unable to get identifier value from response - -1001182111522 - obviously, according to cJSON parse_number function, such value was never going to be stored in item->valueint. Sure, let it go - but why not try to store the value anyways, but as long?