### PR TITLE
Revert "use prev pointer when array do adding"

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -1871,34 +1871,22 @@ static cJSON_bool add_item_to_array(cJSON *array, cJSON *item)
     }
 
     child = array->child;
-    /*
-     * To find the last item int array quickly, we use prev in array
-     */
+
     if (child == NULL)
     {
         /* list is empty, start new one */
         array->child = item;
-        item->prev = item;
-        item->next = NULL;
     }
     else
     {
         /* append to the end */
-        if (child->prev)
+        while (child->next)
         {
-            suffix_object(child->prev, item);
-            array->child->prev = item;
+            child = child->next;
         }
-        else
-        {
-            while (child->next)
-            {
-                child = child->next;
-            }
-            suffix_object(child, item);
-            array->child->prev = item;
-        }
+        suffix_object(child, item);
     }
+
     return true;
 }
 
@@ -2218,20 +2206,13 @@ CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON
     {
         replacement->next->prev = replacement;
     }
-
+    if (replacement->prev != NULL)
+    {
+        replacement->prev->next = replacement;
+    }
     if (parent->child == item)
     {
         parent->child = replacement;
-    }
-    else
-    {   /*
-         * To find the last item int array quickly, we use prev in array.
-         * We can't modify the last item's next pointer where this item was the parent's child
-         */
-        if (replacement->prev != NULL)
-        {
-            replacement->prev->next = replacement;
-        }
     }
 
     item->next = NULL;

--- a/tests/misc_tests.c
+++ b/tests/misc_tests.c
@@ -306,7 +306,7 @@ static void cjson_replace_item_via_pointer_should_replace_items(void)
 
     /* replace beginning */
     TEST_ASSERT_TRUE(cJSON_ReplaceItemViaPointer(array, beginning, &(replacements[0])));
-    TEST_ASSERT_TRUE(replacements[0].prev == end);
+    TEST_ASSERT_NULL(replacements[0].prev);
     TEST_ASSERT_TRUE(replacements[0].next == middle);
     TEST_ASSERT_TRUE(middle->prev == &(replacements[0]));
     TEST_ASSERT_TRUE(array->child == &(replacements[0]));


### PR DESCRIPTION
Reverts DaveGamble/cJSON#430, this causes `cJSON_Detach*` to fail. see #443 and #444 .