### PR TITLE
comparing double value with DBL_EPSILON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ else
 endif
 
 PIC_FLAGS = -fPIC
-R_CFLAGS = $(PIC_FLAGS) -pedantic -Wall -Werror -Wstrict-prototypes -Wwrite-strings -Wshadow -Winit-self -Wcast-align -Wformat=2 -Wmissing-prototypes -Wstrict-overflow=2 -Wcast-qual -Wc++-compat -Wundef -Wswitch-default -Wconversion -Wfloat-equal $(CFLAGS)
+R_CFLAGS = $(PIC_FLAGS) -pedantic -Wall -Werror -Wstrict-prototypes -Wwrite-strings -Wshadow -Winit-self -Wcast-align -Wformat=2 -Wmissing-prototypes -Wstrict-overflow=2 -Wcast-qual -Wc++-compat -Wundef -Wswitch-default -Wconversion $(CFLAGS)
 
 uname := $(shell sh -c 'uname -s 2>/dev/null || echo false')
 

--- a/cJSON.h
+++ b/cJSON.h
@@ -137,11 +137,6 @@ typedef int cJSON_bool;
 #define CJSON_NESTING_LIMIT 1000
 #endif
 
-/* Precision of double variables comparison */
-#ifndef CJSON_DOUBLE_PRECISION
-#define CJSON_DOUBLE_PRECISION .0000000000000001
-#endif
-
 /* returns the version of cJSON as a string */
 CJSON_PUBLIC(const char*) cJSON_Version(void);
 

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -40,6 +40,8 @@
 #include <stdio.h>
 #include <limits.h>
 #include <math.h>
+#include <float.h>
+#include <math.h>
 
 #if defined(_MSC_VER)
 #pragma warning (pop)
@@ -109,7 +111,8 @@ static int compare_strings(const unsigned char *string1, const unsigned char *st
 /* securely comparison of floating-point variables */
 static cJSON_bool compare_double(double a, double b)
 {
-    return (fabs(a - b) <= CJSON_DOUBLE_PRECISION);
+    double maxVal = fabs(a) > fabs(b) ? fabs(a) : fabs(b);
+    return (fabs(a - b) <= maxVal * DBL_EPSILON);
 }
 
 

--- a/tests/compare_tests.c
+++ b/tests/compare_tests.c
@@ -64,6 +64,9 @@ static void cjson_compare_should_compare_numbers(void)
     TEST_ASSERT_TRUE(compare_from_string("1", "1", false));
     TEST_ASSERT_TRUE(compare_from_string("0.0001", "0.0001", true));
     TEST_ASSERT_TRUE(compare_from_string("0.0001", "0.0001", false));
+    TEST_ASSERT_TRUE(compare_from_string("1E100", "10E99", false));
+
+    TEST_ASSERT_FALSE(compare_from_string("0.5E-100", "0.5E-101", false));
 
     TEST_ASSERT_FALSE(compare_from_string("1", "2", true));
     TEST_ASSERT_FALSE(compare_from_string("1", "2", false));


### PR DESCRIPTION
## Changes:
- using fabs(a - b) < DBL_MIN to compare float number
- define isnan and isinf for ANSI C(c89), if not compiling in c89, we could include them from `math.h` directly