### PR TITLE
Add iteration macros for heterogeneous arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ You can also replace an item in an array in place. Either with `cJSON_ReplaceIte
 
 To get the size of an array, use `cJSON_GetArraySize`. Use `cJSON_GetArrayItem` to get an element at a given index.
 
-Because an array is stored as a linked list, iterating it via index is inefficient (`O(n²)`), so you can iterate over an array using the `cJSON_ArrayForEach` macro in `O(n)` time complexity.
+Because an array is stored as a linked list, iterating it via index is inefficient (`O(n²)`), so you can iterate over an array using the `cJSON_ArrayForEach` macro in `O(n)` time complexity. Alternatively, for heterogeneous arrays, the `cJSON_ArrayFirst` and `cJSON_ArrayNext` macros might be more useful.
 
 #### Objects
 

--- a/cJSON.h
+++ b/cJSON.h
@@ -279,8 +279,10 @@ CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number);
 /* Change the valuestring of a cJSON_String object, only takes effect when type of object is cJSON_String */
 CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring);
 
-/* Macro for iterating over an array or object */
+/* Macros for iterating over an array or object */
 #define cJSON_ArrayForEach(element, array) for(element = (array != NULL) ? (array)->child : NULL; element != NULL; element = element->next)
+#define cJSON_ArrayFirst(element, array) (element = (array != NULL) ? (array)->child : NULL)
+#define cJSON_ArrayNext(element) (element = element->next)
 
 /* malloc/free objects using the malloc/free functions that have been set with cJSON_InitHooks */
 CJSON_PUBLIC(void *) cJSON_malloc(size_t size);

--- a/cJSON.h
+++ b/cJSON.h
@@ -281,7 +281,7 @@ CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
 
 /* Macros for iterating over an array or object */
 #define cJSON_ArrayForEach(element, array) for(element = (array != NULL) ? (array)->child : NULL; element != NULL; element = element->next)
-#define cJSON_ArrayFirst(element, array) (element = (array != NULL) ? (array)->child : NULL)
+#define cJSON_ArrayFirst(array, element) (element = (array != NULL) ? (array)->child : NULL)
 #define cJSON_ArrayNext(element) (element = element->next)
 
 /* malloc/free objects using the malloc/free functions that have been set with cJSON_InitHooks */

--- a/tests/misc_tests.c
+++ b/tests/misc_tests.c
@@ -64,6 +64,87 @@ static void cjson_array_foreach_should_not_dereference_null_pointer(void)
     cJSON_ArrayForEach(element, array);
 }
 
+static void cjson_array_first_should_get_first(void)
+{
+    cJSON array[1];
+    cJSON elements[10];
+    cJSON *element_pointer = NULL;
+    size_t i = 0;
+
+    memset(array, 0, sizeof(array));
+    memset(elements, 0, sizeof(elements));
+
+    /* create array */
+    array[0].child = &elements[0];
+    elements[0].prev = NULL;
+    elements[9].next = NULL;
+    for (i = 0; i < 9; i++)
+    {
+        elements[i].next = &elements[i + 1];
+        elements[i + 1].prev = &elements[i];
+    }
+
+    cJSON_ArrayFirst(element_pointer, array);
+    TEST_ASSERT_TRUE_MESSAGE(element_pointer == &elements[0], "Failed to store first.");
+}
+
+static void cjson_array_first_should_not_dereference_null_pointer(void)
+{
+    cJSON *array = NULL;
+    cJSON *element = NULL;
+    cJSON_ArrayFirst(element, array);
+    /* suppress unused var warning */
+    if (element)
+    {
+    }
+}
+
+static void cjson_array_next_should_iterate(void)
+{
+    cJSON array[1];
+    cJSON elements[3];
+    cJSON *element_pointer = NULL;
+    size_t i = 0;
+
+    memset(array, 0, sizeof(array));
+    memset(elements, 0, sizeof(elements));
+
+    /* create array */
+    array[0].child = &elements[0];
+    elements[0].prev = NULL;
+    elements[2].next = NULL;
+    for (i = 0; i < 2; i++)
+    {
+        elements[i].next = &elements[i + 1];
+        elements[i + 1].prev = &elements[i];
+    }
+
+    cJSON_ArrayFirst(element_pointer, array);
+
+    if (cJSON_ArrayNext(element_pointer))
+    {
+        TEST_ASSERT_TRUE_MESSAGE(element_pointer == &elements[1], "Stored incorrect second.");
+    }
+    else
+    {
+        TEST_FAIL_MESSAGE("Failed to store second.");
+    }
+
+    if (cJSON_ArrayNext(element_pointer))
+    {
+        TEST_ASSERT_TRUE_MESSAGE(element_pointer == &elements[2], "Stored incorrect second.");
+    }
+    else
+    {
+        TEST_FAIL_MESSAGE("Failed to store third.");
+    }
+
+    if (cJSON_ArrayNext(element_pointer))
+    {
+        TEST_FAIL_MESSAGE("Failed to return NULL at end of array.");
+    }
+}
+
 static void cjson_get_object_item_should_get_object_items(void)
 {
     cJSON *item = NULL;
@@ -656,6 +737,9 @@ int CJSON_CDECL main(void)
 
     RUN_TEST(cjson_array_foreach_should_loop_over_arrays);
     RUN_TEST(cjson_array_foreach_should_not_dereference_null_pointer);
+    RUN_TEST(cjson_array_first_should_get_first);
+    RUN_TEST(cjson_array_first_should_not_dereference_null_pointer);
+    RUN_TEST(cjson_array_next_should_iterate);
     RUN_TEST(cjson_get_object_item_should_get_object_items);
     RUN_TEST(cjson_get_object_item_case_sensitive_should_get_object_items);
     RUN_TEST(cjson_get_object_item_should_not_crash_with_array);

--- a/tests/misc_tests.c
+++ b/tests/misc_tests.c
@@ -84,7 +84,7 @@ static void cjson_array_first_should_get_first(void)
         elements[i + 1].prev = &elements[i];
     }
 
-    cJSON_ArrayFirst(element_pointer, array);
+    cJSON_ArrayFirst(array, element_pointer);
     TEST_ASSERT_TRUE_MESSAGE(element_pointer == &elements[0], "Failed to store first.");
 }
 
@@ -92,7 +92,7 @@ static void cjson_array_first_should_not_dereference_null_pointer(void)
 {
     cJSON *array = NULL;
     cJSON *element = NULL;
-    cJSON_ArrayFirst(element, array);
+    cJSON_ArrayFirst(array, element);
     /* suppress unused var warning */
     if (element)
     {
@@ -119,7 +119,7 @@ static void cjson_array_next_should_iterate(void)
         elements[i + 1].prev = &elements[i];
     }
 
-    cJSON_ArrayFirst(element_pointer, array);
+    cJSON_ArrayFirst(array, element_pointer);
 
     if (cJSON_ArrayNext(element_pointer))
     {


### PR DESCRIPTION
The `cJSON_ArrayForEach` macro works well in most cases, but not for cases where different actions need to be performed for different elements.

The situation where I ran into this issue was a version array like the following:

```
{
    "version": [1, 2, 3],
    ...
}
```

This would represent version 1.2.3. To check for compatibility, the major version must match exactly, the minor version be equal or greater, and the patch version can be ignored.

To accommodate this sort of situation, this PR adds two additional iteration macros, `cJSON_ArrayFirst` and `cJSON_ArrayNext`. They would be used as follows:

```c
cJSON *version = cJSON_GetObjectItemCaseSensitive(msg, "version");
cJSON *version_item;
if (cJSON_IsArray(version)) {
    if (cJSON_ArrayFirst(version, version_item)) {
        /* Check if version_item is number and == 1 */
    } else {
        return 0;
    }

    if (cJSON_ArrayNext(version_item)) {
        /* Check if version_item is number and >= 2 */
    } else {
        return 0;
    }

    if (cJSON_ArrayNext(version_item)) {
        /* Check if version_item is number */
    } else {
        return 0;
    }

    if (cJSON_ArrayNext(version_item)) {
        return 0;
    }
}
```