### PR TITLE
Problem: WError error on macosx because NAN is a float

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -106,7 +106,7 @@ CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item)
 {
     if (!cJSON_IsNumber(item)) 
     {
-        return NAN;
+        return (double) NAN;
     }
 
     return item->valuedouble;


### PR DESCRIPTION
Solution: Add explicit cast from NAN to double