### PR TITLE
Remove unnecessary files in release tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 *  					text=auto
 /tests/inputs/*	text eol=lf
+
+.gitattributes          export-ignore
+.gitignore              export-ignore
+.github                 export-ignore
+.editorconfig           export-ignore
+.travis.yml             export-ignore


### PR DESCRIPTION
Prior to this patch, we would find '.gitignore', '.travisCI.yml' in
the release tarball.

This patch adds a few entries in .gitattributes to specify files that
should never end up in a distribution tarball.

Signed-off-by: Hu Keping <hukeping@huawei.com>