### PR TITLE
Use space after object keys in pretty-print output; update unit tests

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -92,9 +92,9 @@ CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void)
     return (const char*) (global_error.json + global_error.position);
 }
 
-CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item) 
+CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item)
 {
-    if (!cJSON_IsString(item)) 
+    if (!cJSON_IsString(item))
     {
         return NULL;
     }
@@ -102,9 +102,9 @@ CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item)
     return item->valuestring;
 }
 
-CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item) 
+CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item)
 {
-    if (!cJSON_IsNumber(item)) 
+    if (!cJSON_IsNumber(item))
     {
         return NAN;
     }
@@ -1101,7 +1101,7 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthOpts(const char *value, size_t buffer
     }
 
     buffer.content = (const unsigned char*)value;
-    buffer.length = buffer_length; 
+    buffer.length = buffer_length;
     buffer.offset = 0;
     buffer.hooks = global_hooks;
 
@@ -1765,7 +1765,7 @@ static cJSON_bool print_object(const cJSON * const item, printbuffer * const out
         *output_pointer++ = ':';
         if (output_buffer->format)
         {
-            *output_pointer++ = '\t';
+            *output_pointer++ = ' ';
         }
         output_buffer->offset += length;
 

--- a/tests/inputs/test1.expected
+++ b/tests/inputs/test1.expected
@@ -1,20 +1,20 @@
 {
-	"glossary":	{
-		"title":	"example glossary",
-		"GlossDiv":	{
-			"title":	"S",
-			"GlossList":	{
-				"GlossEntry":	{
-					"ID":	"SGML",
-					"SortAs":	"SGML",
-					"GlossTerm":	"Standard Generalized Markup Language",
-					"Acronym":	"SGML",
-					"Abbrev":	"ISO 8879:1986",
-					"GlossDef":	{
-						"para":	"A meta-markup language, used to create markup languages such as DocBook.",
-						"GlossSeeAlso":	["GML", "XML"]
+	"glossary": {
+		"title": "example glossary",
+		"GlossDiv": {
+			"title": "S",
+			"GlossList": {
+				"GlossEntry": {
+					"ID": "SGML",
+					"SortAs": "SGML",
+					"GlossTerm": "Standard Generalized Markup Language",
+					"Acronym": "SGML",
+					"Abbrev": "ISO 8879:1986",
+					"GlossDef": {
+						"para": "A meta-markup language, used to create markup languages such as DocBook.",
+						"GlossSeeAlso": ["GML", "XML"]
 					},
-					"GlossSee":	"markup"
+					"GlossSee": "markup"
 				}
 			}
 		}

--- a/tests/inputs/test11.expected
+++ b/tests/inputs/test11.expected
@@ -1,10 +1,10 @@
 {
-	"name":	"Jack (\"Bee\") Nimble",
-	"format":	{
-		"type":	"rect",
-		"width":	1920,
-		"height":	1080,
-		"interlace":	false,
-		"frame rate":	24
+	"name": "Jack (\"Bee\") Nimble",
+	"format": {
+		"type": "rect",
+		"width": 1920,
+		"height": 1080,
+		"interlace": false,
+		"frame rate": 24
 	}
 }

--- a/tests/inputs/test2.expected
+++ b/tests/inputs/test2.expected
@@ -1,17 +1,17 @@
 {
-	"menu":	{
-		"id":	"file",
-		"value":	"File",
-		"popup":	{
-			"menuitem":	[{
-					"value":	"New",
-					"onclick":	"CreateNewDoc()"
+	"menu": {
+		"id": "file",
+		"value": "File",
+		"popup": {
+			"menuitem": [{
+					"value": "New",
+					"onclick": "CreateNewDoc()"
 				}, {
-					"value":	"Open",
-					"onclick":	"OpenDoc()"
+					"value": "Open",
+					"onclick": "OpenDoc()"
 				}, {
-					"value":	"Close",
-					"onclick":	"CloseDoc()"
+					"value": "Close",
+					"onclick": "CloseDoc()"
 				}]
 		}
 	}

--- a/tests/inputs/test3.expected
+++ b/tests/inputs/test3.expected
@@ -1,28 +1,28 @@
 {
-	"widget":	{
-		"debug":	"on",
-		"window":	{
-			"title":	"Sample Konfabulator Widget",
-			"name":	"main_window",
-			"width":	500,
-			"height":	500
+	"widget": {
+		"debug": "on",
+		"window": {
+			"title": "Sample Konfabulator Widget",
+			"name": "main_window",
+			"width": 500,
+			"height": 500
 		},
-		"image":	{
-			"src":	"Images/Sun.png",
-			"name":	"sun1",
-			"hOffset":	250,
-			"vOffset":	250,
-			"alignment":	"center"
+		"image": {
+			"src": "Images/Sun.png",
+			"name": "sun1",
+			"hOffset": 250,
+			"vOffset": 250,
+			"alignment": "center"
 		},
-		"text":	{
-			"data":	"Click Here",
-			"size":	36,
-			"style":	"bold",
-			"name":	"text1",
-			"hOffset":	250,
-			"vOffset":	100,
-			"alignment":	"center",
-			"onMouseUp":	"sun1.opacity = (sun1.opacity / 100) * 90;"
+		"text": {
+			"data": "Click Here",
+			"size": 36,
+			"style": "bold",
+			"name": "text1",
+			"hOffset": 250,
+			"vOffset": 100,
+			"alignment": "center",
+			"onMouseUp": "sun1.opacity = (sun1.opacity / 100) * 90;"
 		}
 	}
 }

--- a/tests/inputs/test4.expected
+++ b/tests/inputs/test4.expected
@@ -1,94 +1,94 @@
 {
-	"web-app":	{
-		"servlet":	[{
-				"servlet-name":	"cofaxCDS",
-				"servlet-class":	"org.cofax.cds.CDSServlet",
-				"init-param":	{
-					"configGlossary:installationAt":	"Philadelphia, PA",
-					"configGlossary:adminEmail":	"ksm@pobox.com",
-					"configGlossary:poweredBy":	"Cofax",
-					"configGlossary:poweredByIcon":	"/images/cofax.gif",
-					"configGlossary:staticPath":	"/content/static",
-					"templateProcessorClass":	"org.cofax.WysiwygTemplate",
-					"templateLoaderClass":	"org.cofax.FilesTemplateLoader",
-					"templatePath":	"templates",
-					"templateOverridePath":	"",
-					"defaultListTemplate":	"listTemplate.htm",
-					"defaultFileTemplate":	"articleTemplate.htm",
-					"useJSP":	false,
-					"jspListTemplate":	"listTemplate.jsp",
-					"jspFileTemplate":	"articleTemplate.jsp",
-					"cachePackageTagsTrack":	200,
-					"cachePackageTagsStore":	200,
-					"cachePackageTagsRefresh":	60,
-					"cacheTemplatesTrack":	100,
-					"cacheTemplatesStore":	50,
-					"cacheTemplatesRefresh":	15,
-					"cachePagesTrack":	200,
-					"cachePagesStore":	100,
-					"cachePagesRefresh":	10,
-					"cachePagesDirtyRead":	10,
-					"searchEngineListTemplate":	"forSearchEnginesList.htm",
-					"searchEngineFileTemplate":	"forSearchEngines.htm",
-					"searchEngineRobotsDb":	"WEB-INF/robots.db",
-					"useDataStore":	true,
-					"dataStoreClass":	"org.cofax.SqlDataStore",
-					"redirectionClass":	"org.cofax.SqlRedirection",
-					"dataStoreName":	"cofax",
-					"dataStoreDriver":	"com.microsoft.jdbc.sqlserver.SQLServerDriver",
-					"dataStoreUrl":	"jdbc:microsoft:sqlserver://LOCALHOST:1433;DatabaseName=goon",
-					"dataStoreUser":	"sa",
-					"dataStorePassword":	"dataStoreTestQuery",
-					"dataStoreTestQuery":	"SET NOCOUNT ON;select test='test';",
-					"dataStoreLogFile":	"/usr/local/tomcat/logs/datastore.log",
-					"dataStoreInitConns":	10,
-					"dataStoreMaxConns":	100,
-					"dataStoreConnUsageLimit":	100,
-					"dataStoreLogLevel":	"debug",
-					"maxUrlLength":	500
+	"web-app": {
+		"servlet": [{
+				"servlet-name": "cofaxCDS",
+				"servlet-class": "org.cofax.cds.CDSServlet",
+				"init-param": {
+					"configGlossary:installationAt": "Philadelphia, PA",
+					"configGlossary:adminEmail": "ksm@pobox.com",
+					"configGlossary:poweredBy": "Cofax",
+					"configGlossary:poweredByIcon": "/images/cofax.gif",
+					"configGlossary:staticPath": "/content/static",
+					"templateProcessorClass": "org.cofax.WysiwygTemplate",
+					"templateLoaderClass": "org.cofax.FilesTemplateLoader",
+					"templatePath": "templates",
+					"templateOverridePath": "",
+					"defaultListTemplate": "listTemplate.htm",
+					"defaultFileTemplate": "articleTemplate.htm",
+					"useJSP": false,
+					"jspListTemplate": "listTemplate.jsp",
+					"jspFileTemplate": "articleTemplate.jsp",
+					"cachePackageTagsTrack": 200,
+					"cachePackageTagsStore": 200,
+					"cachePackageTagsRefresh": 60,
+					"cacheTemplatesTrack": 100,
+					"cacheTemplatesStore": 50,
+					"cacheTemplatesRefresh": 15,
+					"cachePagesTrack": 200,
+					"cachePagesStore": 100,
+					"cachePagesRefresh": 10,
+					"cachePagesDirtyRead": 10,
+					"searchEngineListTemplate": "forSearchEnginesList.htm",
+					"searchEngineFileTemplate": "forSearchEngines.htm",
+					"searchEngineRobotsDb": "WEB-INF/robots.db",
+					"useDataStore": true,
+					"dataStoreClass": "org.cofax.SqlDataStore",
+					"redirectionClass": "org.cofax.SqlRedirection",
+					"dataStoreName": "cofax",
+					"dataStoreDriver": "com.microsoft.jdbc.sqlserver.SQLServerDriver",
+					"dataStoreUrl": "jdbc:microsoft:sqlserver://LOCALHOST:1433;DatabaseName=goon",
+					"dataStoreUser": "sa",
+					"dataStorePassword": "dataStoreTestQuery",
+					"dataStoreTestQuery": "SET NOCOUNT ON;select test='test';",
+					"dataStoreLogFile": "/usr/local/tomcat/logs/datastore.log",
+					"dataStoreInitConns": 10,
+					"dataStoreMaxConns": 100,
+					"dataStoreConnUsageLimit": 100,
+					"dataStoreLogLevel": "debug",
+					"maxUrlLength": 500
 				}
 			}, {
-				"servlet-name":	"cofaxEmail",
-				"servlet-class":	"org.cofax.cds.EmailServlet",
-				"init-param":	{
-					"mailHost":	"mail1",
-					"mailHostOverride":	"mail2"
+				"servlet-name": "cofaxEmail",
+				"servlet-class": "org.cofax.cds.EmailServlet",
+				"init-param": {
+					"mailHost": "mail1",
+					"mailHostOverride": "mail2"
 				}
 			}, {
-				"servlet-name":	"cofaxAdmin",
-				"servlet-class":	"org.cofax.cds.AdminServlet"
+				"servlet-name": "cofaxAdmin",
+				"servlet-class": "org.cofax.cds.AdminServlet"
 			}, {
-				"servlet-name":	"fileServlet",
-				"servlet-class":	"org.cofax.cds.FileServlet"
+				"servlet-name": "fileServlet",
+				"servlet-class": "org.cofax.cds.FileServlet"
 			}, {
-				"servlet-name":	"cofaxTools",
-				"servlet-class":	"org.cofax.cms.CofaxToolsServlet",
-				"init-param":	{
-					"templatePath":	"toolstemplates/",
-					"log":	1,
-					"logLocation":	"/usr/local/tomcat/logs/CofaxTools.log",
-					"logMaxSize":	"",
-					"dataLog":	1,
-					"dataLogLocation":	"/usr/local/tomcat/logs/dataLog.log",
-					"dataLogMaxSize":	"",
-					"removePageCache":	"/content/admin/remove?cache=pages&id=",
-					"removeTemplateCache":	"/content/admin/remove?cache=templates&id=",
-					"fileTransferFolder":	"/usr/local/tomcat/webapps/content/fileTransferFolder",
-					"lookInContext":	1,
-					"adminGroupID":	4,
-					"betaServer":	true
+				"servlet-name": "cofaxTools",
+				"servlet-class": "org.cofax.cms.CofaxToolsServlet",
+				"init-param": {
+					"templatePath": "toolstemplates/",
+					"log": 1,
+					"logLocation": "/usr/local/tomcat/logs/CofaxTools.log",
+					"logMaxSize": "",
+					"dataLog": 1,
+					"dataLogLocation": "/usr/local/tomcat/logs/dataLog.log",
+					"dataLogMaxSize": "",
+					"removePageCache": "/content/admin/remove?cache=pages&id=",
+					"removeTemplateCache": "/content/admin/remove?cache=templates&id=",
+					"fileTransferFolder": "/usr/local/tomcat/webapps/content/fileTransferFolder",
+					"lookInContext": 1,
+					"adminGroupID": 4,
+					"betaServer": true
 				}
 			}],
-		"servlet-mapping":	{
-			"cofaxCDS":	"/",
-			"cofaxEmail":	"/cofaxutil/aemail/*",
-			"cofaxAdmin":	"/admin/*",
-			"fileServlet":	"/static/*",
-			"cofaxTools":	"/tools/*"
+		"servlet-mapping": {
+			"cofaxCDS": "/",
+			"cofaxEmail": "/cofaxutil/aemail/*",
+			"cofaxAdmin": "/admin/*",
+			"fileServlet": "/static/*",
+			"cofaxTools": "/tools/*"
 		},
-		"taglib":	{
-			"taglib-uri":	"cofax.tld",
-			"taglib-location":	"/WEB-INF/tlds/cofax.tld"
+		"taglib": {
+			"taglib-uri": "cofax.tld",
+			"taglib-location": "/WEB-INF/tlds/cofax.tld"
 		}
 	}
 }

--- a/tests/inputs/test5.expected
+++ b/tests/inputs/test5.expected
@@ -1,54 +1,54 @@
 {
-	"menu":	{
-		"header":	"SVG Viewer",
-		"items":	[{
-				"id":	"Open"
+	"menu": {
+		"header": "SVG Viewer",
+		"items": [{
+				"id": "Open"
 			}, {
-				"id":	"OpenNew",
-				"label":	"Open New"
+				"id": "OpenNew",
+				"label": "Open New"
 			}, null, {
-				"id":	"ZoomIn",
-				"label":	"Zoom In"
+				"id": "ZoomIn",
+				"label": "Zoom In"
 			}, {
-				"id":	"ZoomOut",
-				"label":	"Zoom Out"
+				"id": "ZoomOut",
+				"label": "Zoom Out"
 			}, {
-				"id":	"OriginalView",
-				"label":	"Original View"
+				"id": "OriginalView",
+				"label": "Original View"
 			}, null, {
-				"id":	"Quality"
+				"id": "Quality"
 			}, {
-				"id":	"Pause"
+				"id": "Pause"
 			}, {
-				"id":	"Mute"
+				"id": "Mute"
 			}, null, {
-				"id":	"Find",
-				"label":	"Find..."
+				"id": "Find",
+				"label": "Find..."
 			}, {
-				"id":	"FindAgain",
-				"label":	"Find Again"
+				"id": "FindAgain",
+				"label": "Find Again"
 			}, {
-				"id":	"Copy"
+				"id": "Copy"
 			}, {
-				"id":	"CopyAgain",
-				"label":	"Copy Again"
+				"id": "CopyAgain",
+				"label": "Copy Again"
 			}, {
-				"id":	"CopySVG",
-				"label":	"Copy SVG"
+				"id": "CopySVG",
+				"label": "Copy SVG"
 			}, {
-				"id":	"ViewSVG",
-				"label":	"View SVG"
+				"id": "ViewSVG",
+				"label": "View SVG"
 			}, {
-				"id":	"ViewSource",
-				"label":	"View Source"
+				"id": "ViewSource",
+				"label": "View Source"
 			}, {
-				"id":	"SaveAs",
-				"label":	"Save As"
+				"id": "SaveAs",
+				"label": "Save As"
 			}, null, {
-				"id":	"Help"
+				"id": "Help"
 			}, {
-				"id":	"About",
-				"label":	"About Adobe CVG Viewer..."
+				"id": "About",
+				"label": "About Adobe CVG Viewer..."
 			}]
 	}
 }

--- a/tests/inputs/test7.expected
+++ b/tests/inputs/test7.expected
@@ -1,19 +1,19 @@
 [{
-		"precision":	"zip",
-		"Latitude":	37.7668,
-		"Longitude":	-122.3959,
-		"Address":	"",
-		"City":	"SAN FRANCISCO",
-		"State":	"CA",
-		"Zip":	"94107",
-		"Country":	"US"
+		"precision": "zip",
+		"Latitude": 37.7668,
+		"Longitude": -122.3959,
+		"Address": "",
+		"City": "SAN FRANCISCO",
+		"State": "CA",
+		"Zip": "94107",
+		"Country": "US"
 	}, {
-		"precision":	"zip",
-		"Latitude":	37.371991,
-		"Longitude":	-122.02602,
-		"Address":	"",
-		"City":	"SUNNYVALE",
-		"State":	"CA",
-		"Zip":	"94085",
-		"Country":	"US"
+		"precision": "zip",
+		"Latitude": 37.371991,
+		"Longitude": -122.02602,
+		"Address": "",
+		"City": "SUNNYVALE",
+		"State": "CA",
+		"Zip": "94085",
+		"Country": "US"
 	}]

--- a/tests/inputs/test8.expected
+++ b/tests/inputs/test8.expected
@@ -1,13 +1,13 @@
 {
-	"Image":	{
-		"Width":	800,
-		"Height":	600,
-		"Title":	"View from 15th Floor",
-		"Thumbnail":	{
-			"Url":	"http:/*www.example.com/image/481989943",
-			"Height":	125,
-			"Width":	"100"
+	"Image": {
+		"Width": 800,
+		"Height": 600,
+		"Title": "View from 15th Floor",
+		"Thumbnail": {
+			"Url": "http:/*www.example.com/image/481989943",
+			"Height": 125,
+			"Width": "100"
 		},
-		"IDs":	[116, 943, 234, 38793]
+		"IDs": [116, 943, 234, 38793]
 	}
 }

--- a/tests/print_object.c
+++ b/tests/print_object.c
@@ -76,16 +76,16 @@ static void print_object_should_print_empty_objects(void)
 static void print_object_should_print_objects_with_one_element(void)
 {
 
-    assert_print_object("{\n\t\"one\":\t1\n}", "{\"one\":1}");
-    assert_print_object("{\n\t\"hello\":\t\"world!\"\n}", "{\"hello\":\"world!\"}");
-    assert_print_object("{\n\t\"array\":\t[]\n}", "{\"array\":[]}");
-    assert_print_object("{\n\t\"null\":\tnull\n}", "{\"null\":null}");
+    assert_print_object("{\n\t\"one\": 1\n}", "{\"one\":1}");
+    assert_print_object("{\n\t\"hello\": \"world!\"\n}", "{\"hello\":\"world!\"}");
+    assert_print_object("{\n\t\"array\": []\n}", "{\"array\":[]}");
+    assert_print_object("{\n\t\"null\": null\n}", "{\"null\":null}");
 }
 
 static void print_object_should_print_objects_with_multiple_elements(void)
 {
-    assert_print_object("{\n\t\"one\":\t1,\n\t\"two\":\t2,\n\t\"three\":\t3\n}", "{\"one\":1,\"two\":2,\"three\":3}");
-    assert_print_object("{\n\t\"one\":\t1,\n\t\"NULL\":\tnull,\n\t\"TRUE\":\ttrue,\n\t\"FALSE\":\tfalse,\n\t\"array\":\t[],\n\t\"world\":\t\"hello\",\n\t\"object\":\t{\n\t}\n}", "{\"one\":1,\"NULL\":null,\"TRUE\":true,\"FALSE\":false,\"array\":[],\"world\":\"hello\",\"object\":{}}");
+    assert_print_object("{\n\t\"one\": 1,\n\t\"two\": 2,\n\t\"three\": 3\n}", "{\"one\":1,\"two\":2,\"three\":3}");
+    assert_print_object("{\n\t\"one\": 1,\n\t\"NULL\": null,\n\t\"TRUE\": true,\n\t\"FALSE\": false,\n\t\"array\": [],\n\t\"world\": \"hello\",\n\t\"object\": {\n\t}\n}", "{\"one\":1,\"NULL\":null,\"TRUE\":true,\"FALSE\":false,\"array\":[],\"world\":\"hello\",\"object\":{}}");
 }
 
 int CJSON_CDECL main(void)

--- a/tests/readme_examples.c
+++ b/tests/readme_examples.c
@@ -29,16 +29,16 @@
 #include "common.h"
 
 static const char *json = "{\n\
-\t\"name\":\t\"Awesome 4K\",\n\
-\t\"resolutions\":\t[{\n\
-\t\t\t\"width\":\t1280,\n\
-\t\t\t\"height\":\t720\n\
+\t\"name\": \"Awesome 4K\",\n\
+\t\"resolutions\": [{\n\
+\t\t\t\"width\": 1280,\n\
+\t\t\t\"height\": 720\n\
 \t\t}, {\n\
-\t\t\t\"width\":\t1920,\n\
-\t\t\t\"height\":\t1080\n\
+\t\t\t\"width\": 1920,\n\
+\t\t\t\"height\": 1080\n\
 \t\t}, {\n\
-\t\t\t\"width\":\t3840,\n\
-\t\t\t\"height\":\t2160\n\
+\t\t\t\"width\": 3840,\n\
+\t\t\t\"height\": 2160\n\
 \t\t}]\n\
 }";
 
@@ -236,9 +236,9 @@ static void supports_full_hd_should_check_for_full_hd_support(void)
 {
     static const char *monitor_without_hd = "{\n\
 \t\t\"name\": \"lame monitor\",\n\
-\t\t\"resolutions\":\t[{\n\
-\t\t\t\"width\":\t640,\n\
-\t\t\t\"height\":\t480\n\
+\t\t\"resolutions\": [{\n\
+\t\t\t\"width\": 640,\n\
+\t\t\t\"height\": 480\n\
 \t\t}]\n\
 }";
 


### PR DESCRIPTION
Fixes #427

(I see the diff contains some stripped trailing whitespace, if you hate these changes I can try to revert it but I doubt it was there on purpose anyway.)