### PR TITLE
Add exported public include directory for cjson

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ endif()
 if (NOT WIN32)
     target_link_libraries("${CJSON_LIB}" m)
 endif()
+target_include_directories(${CJSON_LIB} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/library_config/libcjson.pc.in"
     "${CMAKE_CURRENT_BINARY_DIR}/libcjson.pc" @ONLY)


### PR DESCRIPTION
This is necessary in cases where cjson is built as part of a larger project but is not installed into the system directories  (for example, when cross-compiling) a larger project with multiple sub-cmake projects.