### PR TITLE
Update cJSON_IsNull() function in cJSON.c

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -2903,7 +2903,7 @@ CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON * const item)
 {
     if (item == NULL)
     {
-        return false;
+        return true;
     }
 
     return (item->type & 0xFF) == cJSON_NULL;


### PR DESCRIPTION
In the line 2906, if the item is null then cJSON_IsNull(item) function returns false. I reckon it should return true, otherwise my test program throws segmentation fault in order to access null object.