### PR TITLE
fix: windows build failure about defining nan

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -78,7 +78,11 @@
 #endif
 
 #ifndef NAN
+#ifdef _WIN32
+#define NAN sqrt(-1.0)
+#else
 #define NAN 0.0/0.0
+#endif
 #endif
 
 typedef struct {


### PR DESCRIPTION
`E:\webtob-build\workspace\hth\cJSON.c(109) : error C2124: divide or mod by zero`
Defining nan( `#define NAN 0.0/0.0`) occured windows build failure above.

So, I changed 0.0/0.0 to sqrt(-1.0)

Environment
Windows Server 2008
Visual Studio 9.0
