### PR TITLE
The crash caused by the next pointer of the item not be initialized to NULL

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -1978,6 +1978,7 @@ static cJSON_bool add_item_to_array(cJSON *array, cJSON *item)
         {
             suffix_object(child->prev, item);
             array->child->prev = item;
+            item->next = NULL;
         }
     }
 


### PR DESCRIPTION
The properly running of this code depends on the next pointer being initialized to NULL, otherwise the delete operation will cause a crash on some platforms