### PR TITLE
docs: fix simple typo, transfering -> transferring

### DIFF
--- a/tests/readme_examples.c
+++ b/tests/readme_examples.c
@@ -69,7 +69,7 @@ static char* create_monitor(void)
         goto end;
     }
     /* after creation was successful, immediately add it to the monitor,
-     * thereby transfering ownership of the pointer to it */
+     * thereby transferring ownership of the pointer to it */
     cJSON_AddItemToObject(monitor, "name", name);
 
     resolutions = cJSON_CreateArray();


### PR DESCRIPTION
There is a small typo in tests/readme_examples.c.

Should read `transferring` rather than `transfering`.

