### PR TITLE
Remove always true condition in cJSON.c

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -511,10 +511,8 @@ static unsigned char* ensure(printbuffer * const p, size_t needed)
 
             return NULL;
         }
-        if (newbuffer)
-        {
-            memcpy(newbuffer, p->buffer, p->offset + 1);
-        }
+        
+        memcpy(newbuffer, p->buffer, p->offset + 1);
         p->hooks.deallocate(p->buffer);
     }
     p->length = newsize;


### PR DESCRIPTION
Finded with cppCheck. The newbuffer is already checked before, so this condition is always true. 