### PR TITLE
Manually override the language for `*.h` to correctly identify them as C instead of C++.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 .github                 export-ignore
 .editorconfig           export-ignore
 .travis.yml             export-ignore
+
+# Linguist incorrectly identified the headers as C++, manually override this.
+*.h linguist-language=C


### PR DESCRIPTION
Not a code change, just so that GitHub correctly classifies these files.