### PR TITLE
added const to cJSON_AddItemReferenceTo* item argument

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -2052,7 +2052,7 @@ CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObjectCS(cJSON *object, const char *stri
     return add_item_to_object(object, string, item, &global_hooks, true);
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item)
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToArray(cJSON *array, const cJSON *item)
 {
     if (array == NULL)
     {
@@ -2062,7 +2062,7 @@ CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item
     return add_item_to_array(array, create_reference(item, &global_hooks));
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item)
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, const cJSON *item)
 {
     if ((object == NULL) || (string == NULL))
     {

--- a/cJSON.h
+++ b/cJSON.h
@@ -226,8 +226,8 @@ CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObject(cJSON *object, const char *string
  * writing to `item->string` */
 CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item);
 /* Append reference to item to the specified array/object. Use this when you want to add an existing cJSON to a new cJSON, but don't want to corrupt your existing cJSON. */
-CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item);
-CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item);
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToArray(cJSON *array, const cJSON *item);
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, const cJSON *item);
 
 /* Remove/Detach items from Arrays/Objects. */
 CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item);


### PR DESCRIPTION
Referenced object should never be modified. 
Internally, `create_reference` takes `const cJSON* item` anyway, and making this parameter const is on par with `cJSON_CreateObjectReference`, which also have `const cJSON* child` argument.

Typical use-case:
```c
void my_function(const cJSON* obj)
{
  cJSON* wrapper = cJSON_CreateObject();
  cJSON_AddItemReferenceToObject(wrapper, "foobar", obj); // <--- this fails atm, const needs to be cast away
  // ... do something
  cJSON_Delete(wrapper);
}
```