### PR TITLE
Add library.json for PlatformIO support

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,18 @@
+{
+	"name": "cJSON",
+	"version": "1.7.14",
+	"frameworks": "*",
+	"platforms": "*",
+	"dependencies": [
+	],
+	"build": {
+		"srcFilter": [
+			"-<*>",
+			"+<cJSON.c>"
+		],
+		"flags": [
+			"-I ./"
+		]
+	}
+}
+

--- a/platform.json
+++ b/platform.json
@@ -1,0 +1,18 @@
+{
+	"name": "cJSON",
+	"version": "1.7.14",
+	"frameworks": "*",
+	"platforms": "*",
+	"dependencies": [
+	],
+	"build": {
+		"srcFilter": [
+			"-<*>",
+			"+<cJSON.c>"
+		],
+		"flags": [
+			"-I ./"
+		]
+	}
+}
+


### PR DESCRIPTION
This patch add support for using cJSON as platformIO library. Simply
clone the cJSON repo in PlatformIO Project under "<project_root>/lib"
directory. PlatformIO Library dependency finder will automatically find
it without any extra work needed to use the library in project.

Signed-off-by: Ajay Bhargav <contact@rickeyworld.info>