### PR TITLE
Be less greedy with heap when reallocating

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -483,7 +483,7 @@ static unsigned char* ensure(printbuffer * const p, size_t needed)
     }
     else
     {
-        newsize = needed * 2;
+        newsize = needed + 1;
     }
 
     if (p->hooks.reallocate != NULL)


### PR DESCRIPTION
Change ensure() in cJSON.c to only request what is needed, not double
the size. This is too wasteful when printing large strings.
