### PR TITLE
Add a string version of numbers

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -350,6 +350,12 @@ static cJSON_bool parse_number(cJSON * const item, parse_buffer * const input_bu
 loop_end:
     number_c_string[i] = '\0';
 
+    item->valuestring = (char*) cJSON_strdup(number_c_string, &input_buffer->hooks);
+    if (item->valuestring == NULL)
+    {
+        return false; /* allocation failure */
+    }
+
     number = strtod((const char*)number_c_string, (char**)&after_end);
     if (number_c_string == after_end)
     {

--- a/cJSON.h
+++ b/cJSON.h
@@ -151,6 +151,8 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithLength(const char *value, size_t buffer_len
 /* If you supply a ptr in return_parse_end and parsing fails, then return_parse_end will contain a pointer to the error so will match cJSON_GetErrorPtr(). */
 CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated);
 CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthOpts(const char *value, size_t buffer_length, const char **return_parse_end, cJSON_bool require_null_terminated);
+/* Set keep_number_strings to true and all number strings are copied/kept for you.  This allows unlimited precision, but it's up to you to do something with the string. */
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthNumStringOpts(const char *value, size_t buffer_length, const char **return_parse_end, cJSON_bool require_null_terminated, cJSON_bool keep_number_strings);
 
 /* Render a cJSON entity to text for transfer/storage. */
 CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item);
@@ -178,6 +180,7 @@ CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void);
 /* Check item type and return its value */
 CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item);
 CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item);
+CJSON_PUBLIC(char *) cJSON_GetNumberValueAsString(const cJSON * const item);
 
 /* These functions check the type of an item */
 CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON * const item);
@@ -197,6 +200,7 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateTrue(void);
 CJSON_PUBLIC(cJSON *) cJSON_CreateFalse(void);
 CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool boolean);
 CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num);
+CJSON_PUBLIC(cJSON *) cJSON_CreateNumberAsString(const char *string);
 CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string);
 /* raw json */
 CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw);
@@ -278,6 +282,8 @@ CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number);
 #define cJSON_SetNumberValue(object, number) ((object != NULL) ? cJSON_SetNumberHelper(object, (double)number) : (number))
 /* Change the valuestring of a cJSON_String object, only takes effect when type of object is cJSON_String */
 CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring);
+/* Change the number values and valuestring of the cJSON_Number object.  The number string must be vaild or it will be rejected. */
+CJSON_PUBLIC(char*) cJSON_SetNumberValueAsString(cJSON *object, const char *number);
 
 /* Macro for iterating over an array or object */
 #define cJSON_ArrayForEach(element, array) for(element = (array != NULL) ? (array)->child : NULL; element != NULL; element = element->next)

--- a/tests/parse_array.c
+++ b/tests/parse_array.c
@@ -44,7 +44,7 @@ static void assert_is_array(cJSON *array_item)
 
 static void assert_not_array(const char *json)
 {
-    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 }, false };
     buffer.content = (const unsigned char*)json;
     buffer.length = strlen(json) + sizeof("");
     buffer.hooks = global_hooks;
@@ -55,7 +55,7 @@ static void assert_not_array(const char *json)
 
 static void assert_parse_array(const char *json)
 {
-    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 }, false };
     buffer.content = (const unsigned char*)json;
     buffer.length = strlen(json) + sizeof("");
     buffer.hooks = global_hooks;

--- a/tests/parse_number.c
+++ b/tests/parse_number.c
@@ -30,7 +30,7 @@
 
 static cJSON item[1];
 
-static void assert_is_number(cJSON *number_item)
+static void assert_is_number(cJSON *number_item, cJSON_bool keep_string)
 {
     TEST_ASSERT_NOT_NULL_MESSAGE(number_item, "Item is NULL.");
 
@@ -39,30 +39,63 @@ static void assert_is_number(cJSON *number_item)
     assert_has_type(number_item, cJSON_Number);
     assert_has_no_reference(number_item);
     assert_has_no_const_string(number_item);
-    assert_has_valuestring(number_item);
+    if (keep_string)
+    {
+        assert_has_valuestring(number_item);
+    }
+    else
+    {
+        assert_has_no_valuestring(number_item);
+    }
     assert_has_no_string(number_item);
+}
+
+static void assert_parse_number_internal(const char *string, int integer, double real, cJSON_bool keep_string)
+{
+    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 }, false };
+    buffer.content = (const unsigned char*)string;
+    buffer.length = strlen(string) + sizeof("");
+    buffer.hooks = global_hooks;
+    buffer.keep_number_strings = keep_string;
+
+    TEST_ASSERT_TRUE(parse_number(item, &buffer));
+    assert_is_number(item, keep_string);
+    TEST_ASSERT_EQUAL_INT(integer, item->valueint);
+    TEST_ASSERT_EQUAL_DOUBLE(real, item->valuedouble);
+    if (keep_string)
+    {
+        TEST_ASSERT_EQUAL_STRING_MESSAGE(string, item->valuestring, "The parsed result isn't as expected.");
+    }
+    else
+    {
+        TEST_ASSERT_EQUAL_STRING_MESSAGE(NULL, item->valuestring, "The string should be NULL.");
+    }
+    global_hooks.deallocate(item->valuestring);
+    item->valuestring = NULL;
 }
 
 static void assert_parse_number(const char *string, int integer, double real)
 {
-    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    assert_parse_number_internal(string, integer, real, false);
+    assert_parse_number_internal(string, integer, real, true);
+}
+
+static void assert_parse_number_failure(const char *string)
+{
+    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 }, false };
     buffer.content = (const unsigned char*)string;
     buffer.length = strlen(string) + sizeof("");
     buffer.hooks = global_hooks;
 
-    TEST_ASSERT_TRUE(parse_number(item, &buffer));
-    assert_is_number(item);
-    TEST_ASSERT_EQUAL_INT(integer, item->valueint);
-    TEST_ASSERT_EQUAL_DOUBLE(real, item->valuedouble);
-    TEST_ASSERT_EQUAL_STRING_MESSAGE(string, item->valuestring, "The parsed result isn't as expected.");
-    global_hooks.deallocate(item->valuestring);
-    item->valuestring = NULL;
+    TEST_ASSERT_FALSE(parse_number(item, &buffer));
 }
+
 
 static void parse_number_should_parse_zero(void)
 {
     assert_parse_number("0", 0, 0);
     assert_parse_number("0.0", 0, 0.0);
+    assert_parse_number("-0.0", 0, 0.0);
     assert_parse_number("-0", 0, -0.0);
 }
 
@@ -100,6 +133,56 @@ static void parse_number_should_parse_negative_reals(void)
     assert_parse_number("-123e-128", 0, -123e-128);
 }
 
+static void parse_number_should_parse_large_number(void)
+{
+    assert_parse_number("12884901888", INT_MAX, 1.2884901888e10);
+    assert_parse_number("100000000000000000000000000000000000000000000000000000000000000000.1",
+                        INT_MAX,
+                        99999999999999999209038626283633850822756121694230455365568299008.000000);
+    assert_parse_number("1111111111222222222233333333334444444444555555555566666666667777777777888888888899999999990000000000",
+                        INT_MAX,
+                        1111111111222222222233333333334444444444555555555566666666667777777777888888888899999999990000000000.0);
+    assert_parse_number("1e999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999",
+                        INT_MAX,
+                        (1.0/0.0));
+    assert_parse_number("-1e999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999",
+                        INT_MIN,
+                        (-1.0/0.0));
+    assert_parse_number("1e-999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999",
+                        0,
+                        0.0);
+}
+
+static void parse_number_invalid_checks(void)
+{
+    const char *tests[] = {
+        "",
+        "-",
+        ".",
+        ".0",
+        "0.",
+        "0.0.1",
+        "e",
+        "E",
+        "e10",
+        "E10",
+        "0e",
+        "0E",
+        "1E+",
+        "1E-",
+        "1e1e2",
+        "1E1E2",
+        "09",
+        "0.+",
+    };
+    size_t i = 0;
+
+    for (i = 0; i < sizeof(tests)/sizeof(char *); i++)
+    {
+        assert_parse_number_failure(tests[i]);
+    }
+}
+
 int CJSON_CDECL main(void)
 {
     /* initialize cJSON item */
@@ -110,5 +193,7 @@ int CJSON_CDECL main(void)
     RUN_TEST(parse_number_should_parse_positive_integers);
     RUN_TEST(parse_number_should_parse_positive_reals);
     RUN_TEST(parse_number_should_parse_negative_reals);
+    RUN_TEST(parse_number_should_parse_large_number);
+    RUN_TEST(parse_number_invalid_checks);
     return UNITY_END();
 }

--- a/tests/parse_number.c
+++ b/tests/parse_number.c
@@ -39,7 +39,7 @@ static void assert_is_number(cJSON *number_item)
     assert_has_type(number_item, cJSON_Number);
     assert_has_no_reference(number_item);
     assert_has_no_const_string(number_item);
-    assert_has_no_valuestring(number_item);
+    assert_has_valuestring(number_item);
     assert_has_no_string(number_item);
 }
 
@@ -48,11 +48,15 @@ static void assert_parse_number(const char *string, int integer, double real)
     parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
     buffer.content = (const unsigned char*)string;
     buffer.length = strlen(string) + sizeof("");
+    buffer.hooks = global_hooks;
 
     TEST_ASSERT_TRUE(parse_number(item, &buffer));
     assert_is_number(item);
     TEST_ASSERT_EQUAL_INT(integer, item->valueint);
     TEST_ASSERT_EQUAL_DOUBLE(real, item->valuedouble);
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(string, item->valuestring, "The parsed result isn't as expected.");
+    global_hooks.deallocate(item->valuestring);
+    item->valuestring = NULL;
 }
 
 static void parse_number_should_parse_zero(void)

--- a/tests/parse_object.c
+++ b/tests/parse_object.c
@@ -52,7 +52,7 @@ static void assert_is_child(cJSON *child_item, const char *name, int type)
 
 static void assert_not_object(const char *json)
 {
-    parse_buffer parsebuffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    parse_buffer parsebuffer = { 0, 0, 0, 0, { 0, 0, 0 }, false };
     parsebuffer.content = (const unsigned char*)json;
     parsebuffer.length = strlen(json) + sizeof("");
     parsebuffer.hooks = global_hooks;
@@ -64,7 +64,7 @@ static void assert_not_object(const char *json)
 
 static void assert_parse_object(const char *json)
 {
-    parse_buffer parsebuffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    parse_buffer parsebuffer = { 0, 0, 0, 0, { 0, 0, 0 }, false };
     parsebuffer.content = (const unsigned char*)json;
     parsebuffer.length = strlen(json) + sizeof("");
     parsebuffer.hooks = global_hooks;

--- a/tests/parse_string.c
+++ b/tests/parse_string.c
@@ -45,7 +45,7 @@ static void assert_is_string(cJSON *string_item)
 
 static void assert_parse_string(const char *string, const char *expected)
 {
-    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 }, false };
     buffer.content = (const unsigned char*)string;
     buffer.length = strlen(string) + sizeof("");
     buffer.hooks = global_hooks;
@@ -59,7 +59,7 @@ static void assert_parse_string(const char *string, const char *expected)
 
 static void assert_not_parse_string(const char * const string)
 {
-    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 }, false };
     buffer.content = (const unsigned char*)string;
     buffer.length = strlen(string) + sizeof("");
     buffer.hooks = global_hooks;

--- a/tests/parse_value.c
+++ b/tests/parse_value.c
@@ -43,7 +43,7 @@ static void assert_is_value(cJSON *value_item, int type)
 
 static void assert_parse_value(const char *string, int type)
 {
-    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 }, false };
     buffer.content = (const unsigned char*) string;
     buffer.length = strlen(string) + sizeof("");
     buffer.hooks = global_hooks;

--- a/tests/print_array.c
+++ b/tests/print_array.c
@@ -34,7 +34,7 @@ static void assert_print_array(const char * const expected, const char * const i
     printbuffer formatted_buffer = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
     printbuffer unformatted_buffer = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
 
-    parse_buffer parsebuffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    parse_buffer parsebuffer = { 0, 0, 0, 0, { 0, 0, 0 }, false };
     parsebuffer.content = (const unsigned char*)input;
     parsebuffer.length = strlen(input) + sizeof("");
     parsebuffer.hooks = global_hooks;

--- a/tests/print_number.c
+++ b/tests/print_number.c
@@ -39,6 +39,8 @@ static void assert_print_number(const char *expected, double input)
     buffer.buffer = new_buffer;
 
     memset(item, 0, sizeof(item));
+    item->type = cJSON_Number;
+
     memset(new_buffer, 0, sizeof(new_buffer));
     cJSON_SetNumberValue(item, input);
     TEST_ASSERT_TRUE_MESSAGE(print_number(item, &buffer), "Failed to print number.");
@@ -60,6 +62,23 @@ static void assert_print_number(const char *expected, double input)
         }  
     }    
     TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, buffer.buffer, "Printed number is not as expected.");
+
+    if (0 != strcmp("null", expected))
+    {
+        char * foo = cJSON_SetNumberValueAsString(item, expected);
+
+        if( NULL == foo ) {
+            printf( "Expected: '%s' - got NULL\n", expected);
+        }
+        TEST_ASSERT_NOT_NULL(cJSON_SetNumberValueAsString(item, expected));
+
+        /* Reset the buffer. */
+        buffer.offset = 0;
+        TEST_ASSERT_TRUE_MESSAGE(print_number(item, &buffer), "Failed to print number.");
+
+        /* Free up the new string. */
+        cJSON_free(item->valuestring);
+    }
 }
 
 static void print_number_should_print_zero(void)
@@ -102,11 +121,9 @@ static void print_number_should_print_negative_reals(void)
 
 static void print_number_should_print_non_number(void)
 {
-    TEST_IGNORE();
-    /* FIXME: Cannot test this easily in C89! */
-    /* assert_print_number("null", NaN); */
-    /* assert_print_number("null", INFTY); */
-    /* assert_print_number("null", -INFTY); */
+    assert_print_number("null", (0.0/0.0));     /* NaN */
+    assert_print_number("null", (1.0/0.0));     /* +inf */
+    assert_print_number("null", (-1.0/0.0));    /* -inf */
 }
 
 int CJSON_CDECL main(void)

--- a/tests/print_object.c
+++ b/tests/print_object.c
@@ -33,7 +33,7 @@ static void assert_print_object(const char * const expected, const char * const 
 
     printbuffer formatted_buffer = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
     printbuffer unformatted_buffer = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
-    parse_buffer parsebuffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    parse_buffer parsebuffer = { 0, 0, 0, 0, { 0, 0, 0 }, false };
 
     /* buffer for parsing */
     parsebuffer.content = (const unsigned char*)input;

--- a/tests/print_value.c
+++ b/tests/print_value.c
@@ -33,7 +33,7 @@ static void assert_print_value(const char *input)
     unsigned char printed[1024];
     cJSON item[1];
     printbuffer buffer = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
-    parse_buffer parsebuffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    parse_buffer parsebuffer = { 0, 0, 0, 0, { 0, 0, 0 }, false };
     buffer.buffer = printed;
     buffer.length = sizeof(printed);
     buffer.offset = 0;


### PR DESCRIPTION
This change adds storing the string version of numbers during decoding
so that large or precise numbers can be handled by the program without
the need for cJSON to directly deal with the numbers.  There is still a
63 character limit, but this change enables applications to handle 64
bit numbers while enabling cJSON to maintain C89 support.