### PR TITLE
Use 'strcmp' to compare string literals

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -1062,7 +1062,7 @@ static parse_buffer *skip_utf8_bom(parse_buffer * const buffer)
         return NULL;
     }
 
-    if (can_access_at_index(buffer, 4) && (strncmp((const char*)buffer_at_offset(buffer), "\xEF\xBB\xBF", 3) == 0))
+    if (can_access_at_index(buffer, 4) && (strcmp((const char*)buffer_at_offset(buffer), "\xEF\xBB\xBF") == 0))
     {
         buffer->offset += 3;
     }
@@ -1312,21 +1312,21 @@ static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buf
 
     /* parse the different types of values */
     /* null */
-    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "null", 4) == 0))
+    if (can_read(input_buffer, 4) && (strcmp((const char*)buffer_at_offset(input_buffer), "null") == 0))
     {
         item->type = cJSON_NULL;
         input_buffer->offset += 4;
         return true;
     }
     /* false */
-    if (can_read(input_buffer, 5) && (strncmp((const char*)buffer_at_offset(input_buffer), "false", 5) == 0))
+    if (can_read(input_buffer, 5) && (strcmp((const char*)buffer_at_offset(input_buffer), "false") == 0))
     {
         item->type = cJSON_False;
         input_buffer->offset += 5;
         return true;
     }
     /* true */
-    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "true", 4) == 0))
+    if (can_read(input_buffer, 4) && (strcmp((const char*)buffer_at_offset(input_buffer), "true") == 0))
     {
         item->type = cJSON_True;
         item->valueint = 1;

--- a/fuzzing/afl.c
+++ b/fuzzing/afl.c
@@ -119,7 +119,7 @@ int main(int argc, char** argv)
         goto cleanup;
     }
 
-    if ((argc == 3) && (strncmp(argv[2], "yes", 3) == 0))
+    if ((argc == 3) && (strcmp(argv[2], "yes") == 0))
     {
         int do_format = 0;
         if (json[1] == 'f')


### PR DESCRIPTION
Using 'strncpy' offers the potential for:
 * Coding errors when the string is changed but the size is forgotten
 * Incorrect result if the variable starts with the string literal, but
   also contains additional characters

On the other hand, strcpy with a string literal is guaranteed to be
bounded, and will always compare up to the first null character.

The possibility that the variable string memory is smaller than the
string literal still exists, but if the code has unterminated strings
running around there are other problems.