### PR TITLE
Support create string with length

### DIFF
--- a/cJSON.h
+++ b/cJSON.h
@@ -198,6 +198,7 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateFalse(void);
 CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool boolean);
 CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num);
 CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string);
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringWithLength(const char *string, size_t length);
 /* raw json */
 CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw);
 CJSON_PUBLIC(cJSON *) cJSON_CreateArray(void);
@@ -267,6 +268,7 @@ CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * c
 CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean);
 CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number);
 CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
+CJSON_PUBLIC(cJSON*) cJSON_AddStringWithLengthToObject(cJSON * const object, const char * const name, const char * const string, size_t length);
 CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw);
 CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name);
 CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name);

--- a/tests/cjson_add.c
+++ b/tests/cjson_add.c
@@ -315,6 +315,43 @@ static void cjson_add_string_should_fail_on_allocation_failure(void)
     cJSON_Delete(root);
 }
 
+static void cjson_add_string_with_length_should_add_string(void)
+{
+    cJSON *root = cJSON_CreateObject();
+    cJSON *string = NULL;
+
+    cJSON_AddStringWithLengthToObject(root, "string", "Hello World!", strlen("Hello World!"));
+
+    TEST_ASSERT_NOT_NULL(string = cJSON_GetObjectItemCaseSensitive(root, "string"));
+    TEST_ASSERT_EQUAL_INT(string->type, cJSON_String);
+    TEST_ASSERT_EQUAL_STRING(string->valuestring, "Hello World!");
+
+    cJSON_Delete(root);
+}
+
+static void cjson_add_string_with_length_should_fail_with_null_pointers(void)
+{
+    cJSON *root = cJSON_CreateObject();
+
+    TEST_ASSERT_NULL(cJSON_AddStringWithLengthToObject(NULL, "string", "string", strlen("string")));
+    TEST_ASSERT_NULL(cJSON_AddStringWithLengthToObject(root, NULL, "string", strlen("string")));
+
+    cJSON_Delete(root);
+}
+
+static void cjson_add_string_with_length_should_fail_on_allocation_failure(void)
+{
+    cJSON *root = cJSON_CreateObject();
+
+    cJSON_InitHooks(&failing_hooks);
+
+    TEST_ASSERT_NULL(cJSON_AddStringWithLengthToObject(root, "string", "string", strlen("string")));
+
+    cJSON_InitHooks(NULL);
+
+    cJSON_Delete(root);
+}
+
 static void cjson_add_raw_should_add_raw(void)
 {
     cJSON *root = cJSON_CreateObject();
@@ -454,6 +491,10 @@ int CJSON_CDECL main(void)
     RUN_TEST(cjson_add_string_should_add_string);
     RUN_TEST(cjson_add_string_should_fail_with_null_pointers);
     RUN_TEST(cjson_add_string_should_fail_on_allocation_failure);
+
+    RUN_TEST(cjson_add_string_with_length_should_add_string);
+    RUN_TEST(cjson_add_string_with_length_should_fail_with_null_pointers);
+    RUN_TEST(cjson_add_string_with_length_should_fail_on_allocation_failure);
 
     RUN_TEST(cjson_add_raw_should_add_raw);
     RUN_TEST(cjson_add_raw_should_fail_with_null_pointers);

--- a/tests/cjson_add.c
+++ b/tests/cjson_add.c
@@ -320,11 +320,17 @@ static void cjson_add_string_with_length_should_add_string(void)
     cJSON *root = cJSON_CreateObject();
     cJSON *string = NULL;
 
+
     cJSON_AddStringWithLengthToObject(root, "string", "Hello World!", strlen("Hello World!"));
+    cJSON_AddStringWithLengthToObject(root, "substring", "Hello World!", strlen("Hello World!") - 7);
 
     TEST_ASSERT_NOT_NULL(string = cJSON_GetObjectItemCaseSensitive(root, "string"));
     TEST_ASSERT_EQUAL_INT(string->type, cJSON_String);
     TEST_ASSERT_EQUAL_STRING(string->valuestring, "Hello World!");
+
+    TEST_ASSERT_NOT_NULL(string = cJSON_GetObjectItemCaseSensitive(root, "substring"));
+    TEST_ASSERT_EQUAL_INT(string->type, cJSON_String);
+    TEST_ASSERT_EQUAL_STRING(string->valuestring, "Hello");
 
     cJSON_Delete(root);
 }


### PR DESCRIPTION
In my case, strings are not all end with `\0`, or sometimes I need to add substring of some string into StringObject. So I wrote `cJSON_CreateStringWithLength` for convenience.