### PR TITLE
Adjust the size of cJSON from 64 to 56 through memory alignment

### DIFF
--- a/cJSON.h
+++ b/cJSON.h
@@ -111,10 +111,10 @@ typedef struct cJSON
     /* The type of the item, as above. */
     int type;
 
-    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
-    char *valuestring;
     /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
     int valueint;
+    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
+    char *valuestring;
     /* The item's number, if type==cJSON_Number */
     double valuedouble;
 

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -840,7 +840,7 @@ static int apply_patch(cJSON *object, const cJSON *patch, const cJSON_bool case_
     {
         if (opcode == REMOVE)
         {
-            static const cJSON invalid = { NULL, NULL, NULL, cJSON_Invalid, NULL, 0, 0, NULL};
+            static const cJSON invalid = { NULL, NULL, NULL, cJSON_Invalid, 0, NULL, 0, NULL};
 
             overwrite_item(object, invalid);
 

--- a/tests/misc_tests.c
+++ b/tests/misc_tests.c
@@ -221,7 +221,7 @@ static void cjson_should_not_parse_to_deeply_nested_jsons(void)
 
 static void cjson_set_number_value_should_set_numbers(void)
 {
-    cJSON number[1] = {{NULL, NULL, NULL, cJSON_Number, NULL, 0, 0, NULL}};
+    cJSON number[1] = {{NULL, NULL, NULL, cJSON_Number, 0, NULL, 0, NULL}};
 
     cJSON_SetNumberValue(number, 1.5);
     TEST_ASSERT_EQUAL(1, number->valueint);
@@ -329,7 +329,7 @@ static void cjson_replace_item_via_pointer_should_replace_items(void)
 
 static void cjson_replace_item_in_object_should_preserve_name(void)
 {
-    cJSON root[1] = {{ NULL, NULL, NULL, 0, NULL, 0, 0, NULL }};
+    cJSON root[1] = {{ NULL, NULL, NULL, 0, 0, NULL, 0, NULL }};
     cJSON *child = NULL;
     cJSON *replacement = NULL;
     cJSON_bool flag = false;


### PR DESCRIPTION
By adjusting the position, the `valueint` and `type`
memory are aligned, occupying a total of 8 bytes
instead of 16 bytes, so sizeof(cJSON) is reduced
from 64 bytes to 56 bytes.

p.s. Although this optimization may not be
effective in the memory allocator's view, because
the size that the allocator may allocate is 64 bytes,
it may be effective in some scenarios, and it will
not be worse than the current situation.

code:
```
#include <stdio.h>

/* The cJSON structure: */
typedef struct cJSON
{
    /* next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem */
    struct cJSON *next;
    struct cJSON *prev;
    /* An array or object item will have a child pointer pointing to a chain of the items in the array/object. */
    struct cJSON *child;

    /* The type of the item, as above. */
    int type;

    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
    char *valuestring;
    /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
    int valueint;
    /* The item's number, if type==cJSON_Number */
    double valuedouble;

    /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
    char *string;
} cJSON;

/* The cJSON structure: */
typedef struct cJSONAfter
{
    /* next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem */
    struct cJSON *next;
    struct cJSON *prev;
    /* An array or object item will have a child pointer pointing to a chain of the items in the array/object. */
    struct cJSON *child;

    /* The type of the item, as above. */
    int type;

    /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
    int valueint;
    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
    char *valuestring;
    /* The item's number, if type==cJSON_Number */
    double valuedouble;

    /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
    char *string;
} cJSONAfter;


int main() {

    printf("before: %lu ,after: %lu", sizeof(cJSON), sizeof(cJSONAfter));
    return 0;
}
```

> $./a.out
before: 64 ,after: 56