### PR TITLE
add CIFuzz integration

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,24 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'cjson'
+        dry-run: false
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'cjson'
+        fuzz-seconds: 600
+        dry-run: false
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
Add CIFuzz Github action to build and run fuzzers on pull requests.

This will run the fuzzers for 600 seconds (split between all the fuzzers) in the CI when a pull request is made, and is used to catch bugs early and also catch regressions. CIFuzz is a service run in parallel with OSS-Fuzz, which cJSON is already integrated into.

Documentation for CIFuzz can be found here: https://google.github.io/oss-fuzz/getting-started/continuous-integration/

Signed-off-by: David Korczynski <david@adalogics.com>