### PR TITLE
Ignore all .dylib files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ test
 *.swp
 *.patch
 tags
-*.dylib
+*.dylib*
 build/
 cJSON_test
 cJSON_test_utils


### PR DESCRIPTION
This fixes some .dylib files being flagged as added when compiled e.g. `libcjson.dylib.1.7.14`