### PR TITLE
fix:print_number() print incorrect integer

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -564,15 +564,22 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     }
     else
     {
-        /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
-        length = sprintf((char*)number_buffer, "%1.15g", d);
+	    if(item->valuedouble == item->valueint)
+	    {
+		    length = sprintf((char*)number_buffer, "%d", item->valueint);
+	    }
+	    else
+	    {
+		    /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
+		    length = sprintf((char*)number_buffer, "%1.15g", d);
 
-        /* Check whether the original double can be recovered */
-        if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || !compare_double((double)test, d))
-        {
-            /* If not, print with 17 decimal places of precision */
-            length = sprintf((char*)number_buffer, "%1.17g", d);
-        }
+		    /* Check whether the original double can be recovered */
+		    if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || !compare_double((double)test, d))
+		    {
+			    /* If not, print with 17 decimal places of precision */
+			    length = sprintf((char*)number_buffer, "%1.17g", d);
+		    }
+	    }
     }
 
     /* sprintf failed or buffer overrun occurred */


### PR DESCRIPTION
In the sub function print_number(), i saw that "number_buffer" was filled with 5.30498947741318e-315 when item->valuedouble = 1