### PR TITLE
MOX-6029 replace unbounded string operations with safer bounded operations

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -405,9 +405,11 @@ CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
     {
         return NULL;
     }
-    if (strlen(valuestring) <= strlen(object->valuestring))
+    int objectLen = strlen(object->valuestring);
+    if (strlen(valuestring) <= objectLen)
     {
-        strncpy(object->valuestring, valuestring, strlen(object->valuestring));
+        strncpy(object->valuestring, valuestring, objectLen+1);
+        object->valuestring[objectLen] = '\0';
         return object->valuestring;
     }
     copy = (char*) cJSON_strdup((const unsigned char*)valuestring, &global_hooks);
@@ -1382,6 +1384,7 @@ static cJSON_bool print_value(const cJSON * const item, printbuffer * const outp
                 return false;
             }
             strncpy((char*)output, "null", 5);
+            output[4] = 0;
             return true;
 
         case cJSON_False:
@@ -1391,6 +1394,7 @@ static cJSON_bool print_value(const cJSON * const item, printbuffer * const outp
                 return false;
             }
             strncpy((char*)output, "false", 6);
+            output[5] = 0;
             return true;
 
         case cJSON_True:
@@ -1400,6 +1404,7 @@ static cJSON_bool print_value(const cJSON * const item, printbuffer * const outp
                 return false;
             }
             strncpy((char*)output, "true", 5);
+            output[4] = 0;
             return true;
 
         case cJSON_Number:

--- a/cJSON.c
+++ b/cJSON.c
@@ -407,7 +407,7 @@ CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
     }
     if (strlen(valuestring) <= strlen(object->valuestring))
     {
-        strcpy(object->valuestring, valuestring);
+        strncpy(object->valuestring, valuestring, strlen(object->valuestring));
         return object->valuestring;
     }
     copy = (char*) cJSON_strdup((const unsigned char*)valuestring, &global_hooks);
@@ -921,7 +921,7 @@ static cJSON_bool print_string_ptr(const unsigned char * const input, printbuffe
         {
             return false;
         }
-        strcpy((char*)output, "\"\"");
+        strncpy((char*)output, "\"\"", sizeof("\"\""));
 
         return true;
     }
@@ -1381,7 +1381,7 @@ static cJSON_bool print_value(const cJSON * const item, printbuffer * const outp
             {
                 return false;
             }
-            strcpy((char*)output, "null");
+            strncpy((char*)output, "null", 5);
             return true;
 
         case cJSON_False:
@@ -1390,7 +1390,7 @@ static cJSON_bool print_value(const cJSON * const item, printbuffer * const outp
             {
                 return false;
             }
-            strcpy((char*)output, "false");
+            strncpy((char*)output, "false", 6);
             return true;
 
         case cJSON_True:
@@ -1399,7 +1399,7 @@ static cJSON_bool print_value(const cJSON * const item, printbuffer * const outp
             {
                 return false;
             }
-            strcpy((char*)output, "true");
+            strncpy((char*)output, "true", 5);
             return true;
 
         case cJSON_Number:


### PR DESCRIPTION
We've (https://moxion.io) recently upgraded the automated code security audits used to check code commits.  The audit flagged several unbounded string operations in cJSON (strcpy).  This PR replaces them with the safer bounded functions (strncpy) and lets the code pass security audits.