### PR TITLE
Make hex literal upper case for consistency

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -2910,7 +2910,7 @@ CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON * const item)
         return false;
     }
 
-    return (item->type & 0xff) == cJSON_True;
+    return (item->type & 0xFF) == cJSON_True;
 }
 
 


### PR DESCRIPTION
There was one hex literal that was lowercase and every other is already uppercase so I made them all uppercase for consistency :)