### PR TITLE
feat: add int64 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,9 @@ jobs:
         compiler:
           - GCC
           - CLANG
+        features:
+          - ENABLE_INT64
+          - NONE_FEATURES
     steps:
     - uses: actions/checkout@v2
     - name: install build dependencies
@@ -47,14 +50,19 @@ jobs:
           else
             export CC=clang
           fi
+          if [ "${{ matrix.features }}" == "ENABLE_INT64" ]; then
+            FEATURE_CMAKE_OPTIONS="-DENABLE_INT64=ON"
+          else
+            FEATURE_CMAKE_OPTIONS="-DENABLE_INT64=OFF"
+          fi
           #run build and test
           JOBS=20
           export CTEST_PARALLEL_LEVEL=$JOBS
           export CTEST_OUTPUT_ON_FAILURE=1
           mkdir -p build
           cd build
-          echo [cmake]: cmake .. $EVENT_CMAKE_OPTIONS
-          cmake .. $EVENT_CMAKE_OPTIONS || (rm -rf * && cmake .. $EVENT_CMAKE_OPTIONS)
+          echo [cmake]: cmake .. $EVENT_CMAKE_OPTIONS $FEATURE_CMAKE_OPTIONS
+          cmake .. $EVENT_CMAKE_OPTIONS $FEATURE_CMAKE_OPTIONS || (rm -rf * && cmake .. $EVENT_CMAKE_OPTIONS $FEATURE_CMAKE_OPTIONS)
           cmake --build .
           make
           make test
@@ -72,6 +80,9 @@ jobs:
         compiler:
           - GCC
           - CLANG
+        features:
+          - ENABLE_INT64
+          - NONE_FEATURES
     steps:
     - uses: actions/checkout@v2
     - name: build and test
@@ -89,14 +100,19 @@ jobs:
           else
             export CC=clang
           fi
+          if [ "${{ matrix.features }}" == "ENABLE_INT64" ]; then
+            FEATURE_CMAKE_OPTIONS="-DENABLE_INT64=ON"
+          else
+            FEATURE_CMAKE_OPTIONS="-DENABLE_INT64=OFF"
+          fi
           #run build and test
           JOBS=20
           export CTEST_PARALLEL_LEVEL=$JOBS
           export CTEST_OUTPUT_ON_FAILURE=1
           mkdir -p build
           cd build
-          echo [cmake]: cmake .. $EVENT_CMAKE_OPTIONS
-          cmake .. $EVENT_CMAKE_OPTIONS || (rm -rf * && cmake .. $EVENT_CMAKE_OPTIONS)
+          echo [cmake]: cmake .. $EVENT_CMAKE_OPTIONS $FEATURE_CMAKE_OPTIONS
+          cmake .. $EVENT_CMAKE_OPTIONS $FEATURE_CMAKE_OPTIONS || (rm -rf * && cmake .. $EVENT_CMAKE_OPTIONS $FEATURE_CMAKE_OPTIONS)
           cmake --build .
           make
           make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,23 @@ set(CJSON_UTILS_VERSION_SO 1)
 
 set(custom_compiler_flags)
 
+option(ENABLE_INT64 "Enable the use of int64(long long), please note this will use c99 instead of c89" OFF)
+if (ENABLE_INT64)
+    add_definitions(-DENABLE_INT64)
+    list(APPEND custom_compiler_flags
+        -std=c99
+    )
+else()
+    list(APPEND custom_compiler_flags
+        -std=c89
+    )
+endif ()
+
 include(CheckCCompilerFlag)
 option(ENABLE_CUSTOM_COMPILER_FLAGS "Enables custom compiler flags" ON)
 if (ENABLE_CUSTOM_COMPILER_FLAGS)
     if (("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang") OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU"))
         list(APPEND custom_compiler_flags
-            -std=c89
             -pedantic
             -Wall
             -Wextra

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ You can change the build process with a list of different options that you can p
 * `-DENABLE_LOCALES=On`: Enable the usage of localeconv method. ( on by default )
 * `-DCJSON_OVERRIDE_BUILD_SHARED_LIBS=On`: Enable overriding the value of `BUILD_SHARED_LIBS` with `-DCJSON_BUILD_SHARED_LIBS`.
 * `-DENABLE_CJSON_VERSION_SO`: Enable cJSON so version. ( on by default )
+* `-DENABLE_INT64`: Enable int64 support for cjson. Please note this will use c99 instead of c89. ( off by default )
 
 If you are packaging cJSON for a distribution of Linux, you would probably take these steps for example:
 ```

--- a/cJSON.h
+++ b/cJSON.h
@@ -85,6 +85,11 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 
 #include <stddef.h>
 
+/* use int64 if it is enabled and supported */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L && defined(ENABLE_INT64)
+#define __CJSON_USE_INT64
+#endif
+
 /* cJSON Types: */
 #define cJSON_Invalid (0)
 #define cJSON_False  (1 << 0)
@@ -98,6 +103,9 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 
 #define cJSON_IsReference 256
 #define cJSON_StringIsConst 512
+#ifdef __CJSON_USE_INT64
+#define cJSON_IsInt64 1024
+#endif
 
 /* The cJSON structure: */
 typedef struct cJSON
@@ -113,8 +121,13 @@ typedef struct cJSON
 
     /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
     char *valuestring;
+#ifdef __CJSON_USE_INT64
+    /* use long long if int64 is enabled */
+    long long valueint;
+#else
     /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
     int valueint;
+#endif /* __CJSON_USE_INT64 */
     /* The item's number, if type==cJSON_Number */
     double valuedouble;
 
@@ -177,6 +190,9 @@ CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void);
 
 /* Check item type and return its value */
 CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item);
+#ifdef __CJSON_USE_INT64
+CJSON_PUBLIC(long long *) cJSON_GetInt64NumberValue(cJSON * const item);
+#endif
 CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item);
 
 /* These functions check the type of an item */
@@ -185,6 +201,9 @@ CJSON_PUBLIC(cJSON_bool) cJSON_IsFalse(const cJSON * const item);
 CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON * const item);
 CJSON_PUBLIC(cJSON_bool) cJSON_IsBool(const cJSON * const item);
 CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON * const item);
+#ifdef __CJSON_USE_INT64
+CJSON_PUBLIC(cJSON_bool) cJSON_IsInt64Number(const cJSON * const item);
+#endif
 CJSON_PUBLIC(cJSON_bool) cJSON_IsNumber(const cJSON * const item);
 CJSON_PUBLIC(cJSON_bool) cJSON_IsString(const cJSON * const item);
 CJSON_PUBLIC(cJSON_bool) cJSON_IsArray(const cJSON * const item);
@@ -197,6 +216,9 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateTrue(void);
 CJSON_PUBLIC(cJSON *) cJSON_CreateFalse(void);
 CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool boolean);
 CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num);
+#ifdef __CJSON_USE_INT64
+CJSON_PUBLIC(cJSON *) cJSON_CreateInt64Number(long long integer);
+#endif
 CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string);
 /* raw json */
 CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw);
@@ -265,12 +287,18 @@ CJSON_PUBLIC(cJSON*) cJSON_AddNullToObject(cJSON * const object, const char * co
 CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObject(cJSON * const object, const char * const name);
 CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * const name);
 CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean);
+#ifdef __CJSON_USE_INT64
+CJSON_PUBLIC(cJSON*) cJSON_AddInt64NumberToObject(cJSON * const object, const char * const name, const long long integer);
+#endif
 CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number);
 CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
 CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw);
 CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name);
 CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name);
 
+#ifdef __CJSON_USE_INT64
+CJSON_PUBLIC(long long) cJSON_SetInt64NumberValue(cJSON * const object, const long long integer);
+#endif
 /* When assigning an integer value, it needs to be propagated to valuedouble too. */
 #define cJSON_SetIntValue(object, number) ((object) ? (object)->valueint = (object)->valuedouble = (number) : (number))
 /* helper for the cJSON_SetNumberValue macro */

--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -610,6 +610,22 @@ static cJSON_bool compare_json(cJSON *a, cJSON *b, const cJSON_bool case_sensiti
     }
     switch (a->type & 0xFF)
     {
+#ifdef __CJSON_USE_INT64
+        case cJSON_Number:
+            /* numeric mismatch. */
+            if ((a->valueint != b->valueint) || (!compare_double(a->valuedouble, b->valuedouble)))
+            {
+                return false;
+            }
+
+            if ((a->type & cJSON_IsInt64) != (b->type & cJSON_IsInt64))
+            {
+                /* cJSON_IsInt64 should also be considered */
+                return false;
+            }
+
+            return true;
+#else
         case cJSON_Number:
             /* numeric mismatch. */
             if ((a->valueint != b->valueint) || (!compare_double(a->valuedouble, b->valuedouble)))
@@ -620,6 +636,7 @@ static cJSON_bool compare_json(cJSON *a, cJSON *b, const cJSON_bool case_sensiti
             {
                 return true;
             }
+#endif /* __CJSON_USE_INT64 */
 
         case cJSON_String:
             /* string mismatch. */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,12 @@ if(ENABLE_CJSON_TEST)
         minify_tests
     )
 
+    if (ENABLE_INT64)
+        add_definitions(-DUNITY_SUPPORT_64)
+        list(APPEND unity_tests
+            misc_int64_tests
+        )
+    endif()
     option(ENABLE_VALGRIND OFF "Enable the valgrind memory checker for the tests.")
     if (ENABLE_VALGRIND)
         find_program(MEMORYCHECK_COMMAND valgrind)

--- a/tests/cjson_add.c
+++ b/tests/cjson_add.c
@@ -278,6 +278,47 @@ static void cjson_add_number_should_fail_on_allocation_failure(void)
     cJSON_Delete(root);
 }
 
+#ifdef __CJSON_USE_INT64
+static void cjson_add_number_should_add_int64_number(void)
+{
+    cJSON *root = cJSON_CreateObject();
+    cJSON *number = NULL;
+
+    cJSON_AddInt64NumberToObject(root, "number", 42LL);
+
+    TEST_ASSERT_NOT_NULL(number = cJSON_GetObjectItemCaseSensitive(root, "number"));
+
+    TEST_ASSERT_EQUAL_INT(number->type, cJSON_Number | cJSON_IsInt64);
+    TEST_ASSERT_EQUAL_DOUBLE(number->valuedouble, 42);
+    TEST_ASSERT_EQUAL_INT64(number->valueint, 42LL);
+
+    cJSON_Delete(root);
+}
+
+static void cjson_add_int64_number_should_fail_on_null_pointers(void)
+{
+    cJSON *root = cJSON_CreateObject();
+
+    TEST_ASSERT_NULL(cJSON_AddInt64NumberToObject(NULL, "number", 42LL));
+    TEST_ASSERT_NULL(cJSON_AddInt64NumberToObject(root, NULL, 42LL));
+
+    cJSON_Delete(root);
+}
+
+static void cjson_add_int64_number_should_fail_on_allocation_failure(void)
+{
+    cJSON *root = cJSON_CreateObject();
+
+    cJSON_InitHooks(&failing_hooks);
+
+    TEST_ASSERT_NULL(cJSON_AddInt64NumberToObject(root, "number", 42LL));
+
+    cJSON_InitHooks(NULL);
+
+    cJSON_Delete(root);
+}
+#endif /* __CJSON_USE_INT64 */
+
 static void cjson_add_string_should_add_string(void)
 {
     cJSON *root = cJSON_CreateObject();
@@ -450,6 +491,12 @@ int CJSON_CDECL main(void)
     RUN_TEST(cjson_add_number_should_add_number);
     RUN_TEST(cjson_add_number_should_fail_with_null_pointers);
     RUN_TEST(cjson_add_number_should_fail_on_allocation_failure);
+
+#ifdef __CJSON_USE_INT64
+    RUN_TEST(cjson_add_number_should_add_int64_number);
+    RUN_TEST(cjson_add_int64_number_should_fail_on_null_pointers);
+    RUN_TEST(cjson_add_int64_number_should_fail_on_allocation_failure);
+#endif /* __CJSON_USE_INT64 */
 
     RUN_TEST(cjson_add_string_should_add_string);
     RUN_TEST(cjson_add_string_should_fail_with_null_pointers);

--- a/tests/compare_tests.c
+++ b/tests/compare_tests.c
@@ -72,6 +72,21 @@ static void cjson_compare_should_compare_numbers(void)
     TEST_ASSERT_FALSE(compare_from_string("1", "2", false));
 }
 
+#ifdef __CJSON_USE_INT64
+static void cjson_compare_should_compare_int64_numbers(void)
+{
+    TEST_ASSERT_TRUE(compare_from_string("1", "1", true));
+    TEST_ASSERT_TRUE(compare_from_string("1", "1", false));
+    TEST_ASSERT_TRUE(compare_from_string("9223372036854775807", "9223372036854775807", true));
+    TEST_ASSERT_TRUE(compare_from_string("9223372036854775807", "9223372036854775807", false));
+    TEST_ASSERT_TRUE(compare_from_string("-9223372036854775808", "-9223372036854775808", true));
+    TEST_ASSERT_TRUE(compare_from_string("-9223372036854775808", "-9223372036854775808", false));
+
+    TEST_ASSERT_FALSE(compare_from_string("1", "2", true));
+    TEST_ASSERT_FALSE(compare_from_string("1", "2", false));
+}
+#endif /* __CJSON_USE_INT64 */
+
 static void cjson_compare_should_compare_booleans(void)
 {
     /* true */
@@ -196,6 +211,9 @@ int CJSON_CDECL main(void)
     RUN_TEST(cjson_compare_should_compare_null_pointer_as_not_equal);
     RUN_TEST(cjson_compare_should_compare_invalid_as_not_equal);
     RUN_TEST(cjson_compare_should_compare_numbers);
+#ifdef __CJSON_USE_INT64
+    RUN_TEST(cjson_compare_should_compare_int64_numbers);
+#endif
     RUN_TEST(cjson_compare_should_compare_booleans);
     RUN_TEST(cjson_compare_should_compare_null);
     RUN_TEST(cjson_compare_should_not_accept_invalid_types);

--- a/tests/misc_int64_tests.c
+++ b/tests/misc_int64_tests.c
@@ -1,0 +1,185 @@
+/*
+  Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "unity/examples/unity_config.h"
+#include "unity/src/unity.h"
+#include "common.h"
+
+static void assert_is_int64(cJSON *int64_number_item)
+{
+    assert_has_type(int64_number_item, cJSON_Number);
+    TEST_ASSERT_BITS_MESSAGE(cJSON_IsInt64, cJSON_IsInt64, int64_number_item->type, "Item should be a int64 integer.");
+}
+
+static void cjson_get_object_item_should_get_object_items_with_int64(void)
+{
+    cJSON *item = NULL;
+    cJSON *found = NULL;
+
+    item = cJSON_Parse("{\"one\":1, \"Two\":2, \"tHree\":3}");
+
+    found = cJSON_GetObjectItem(NULL, "test");
+    TEST_ASSERT_NULL_MESSAGE(found, "Failed to fail on NULL pointer.");
+
+    found = cJSON_GetObjectItem(item, NULL);
+    TEST_ASSERT_NULL_MESSAGE(found, "Failed to fail on NULL string.");
+
+    found = cJSON_GetObjectItem(item, "one");
+    TEST_ASSERT_NOT_NULL_MESSAGE(found, "Failed to find first item.");
+    TEST_ASSERT_EQUAL_DOUBLE(found->valuedouble, 1);
+    assert_is_int64(found);
+
+    found = cJSON_GetObjectItem(item, "tWo");
+    TEST_ASSERT_NOT_NULL_MESSAGE(found, "Failed to find first item.");
+    TEST_ASSERT_EQUAL_DOUBLE(found->valuedouble, 2);
+    assert_is_int64(found);
+
+    found = cJSON_GetObjectItem(item, "three");
+    TEST_ASSERT_NOT_NULL_MESSAGE(found, "Failed to find item.");
+    TEST_ASSERT_EQUAL_DOUBLE(found->valuedouble, 3);
+    assert_is_int64(found);
+
+    found = cJSON_GetObjectItem(item, "four");
+    TEST_ASSERT_NULL_MESSAGE(found, "Should not find something that isn't there.");
+
+    cJSON_Delete(item);
+}
+
+static void cjson_get_object_item_case_sensitive_should_get_object_items_with_int64(void)
+{
+    cJSON *item = NULL;
+    cJSON *found = NULL;
+
+    item = cJSON_Parse("{\"one\":1, \"Two\":2, \"tHree\":3}");
+
+    found = cJSON_GetObjectItemCaseSensitive(NULL, "test");
+    TEST_ASSERT_NULL_MESSAGE(found, "Failed to fail on NULL pointer.");
+
+    found = cJSON_GetObjectItemCaseSensitive(item, NULL);
+    TEST_ASSERT_NULL_MESSAGE(found, "Failed to fail on NULL string.");
+
+    found = cJSON_GetObjectItemCaseSensitive(item, "one");
+    TEST_ASSERT_NOT_NULL_MESSAGE(found, "Failed to find first item.");
+    TEST_ASSERT_EQUAL_DOUBLE(found->valuedouble, 1);
+    assert_is_int64(found);
+
+    found = cJSON_GetObjectItemCaseSensitive(item, "Two");
+    TEST_ASSERT_NOT_NULL_MESSAGE(found, "Failed to find first item.");
+    TEST_ASSERT_EQUAL_DOUBLE(found->valuedouble, 2);
+    assert_is_int64(found);
+
+    found = cJSON_GetObjectItemCaseSensitive(item, "tHree");
+    TEST_ASSERT_NOT_NULL_MESSAGE(found, "Failed to find item.");
+    TEST_ASSERT_EQUAL_DOUBLE(found->valuedouble, 3);
+    assert_is_int64(found);
+
+    found = cJSON_GetObjectItemCaseSensitive(item, "One");
+    TEST_ASSERT_NULL_MESSAGE(found, "Should not find something that isn't there.");
+
+    cJSON_Delete(item);
+}
+
+static void cjson_set_number_value_should_set_numbers_with_int64(void)
+{
+    cJSON number[1] = {{NULL, NULL, NULL, cJSON_Number | cJSON_IsInt64, NULL, 0, 0, NULL}};
+
+    cJSON_SetInt64NumberValue(number, 1LL);
+    TEST_ASSERT_EQUAL_INT64(1LL, number->valueint);
+    TEST_ASSERT_EQUAL_DOUBLE(1.0, number->valuedouble);
+
+    cJSON_SetInt64NumberValue(number, -1LL);
+    TEST_ASSERT_EQUAL_INT64(-1LL, number->valueint);
+    TEST_ASSERT_EQUAL_DOUBLE(-1.0, number->valuedouble);
+
+    cJSON_SetInt64NumberValue(number, 0LL);
+    TEST_ASSERT_EQUAL_INT64(0LL, number->valueint);
+    TEST_ASSERT_EQUAL_DOUBLE(0.0, number->valuedouble);
+
+    cJSON_SetInt64NumberValue(number, LLONG_MAX);
+    TEST_ASSERT_EQUAL_INT64(LLONG_MAX, number->valueint);
+    TEST_ASSERT_EQUAL_DOUBLE((double)LLONG_MAX, number->valuedouble);
+
+    cJSON_SetInt64NumberValue(number, LLONG_MIN);
+    TEST_ASSERT_EQUAL_INT64(LLONG_MIN, number->valueint);
+    TEST_ASSERT_EQUAL_DOUBLE((double)LLONG_MIN, number->valuedouble);
+}
+
+static void typecheck_functions_should_check_type_with_int64(void)
+{
+    cJSON item[1];
+    item->type = cJSON_Number;
+    TEST_ASSERT_FALSE(cJSON_IsInt64Number(item));
+
+    item->type = cJSON_IsInt64;
+    TEST_ASSERT_FALSE(cJSON_IsInt64Number(item));
+
+    item->type = cJSON_Number | cJSON_IsInt64;
+    TEST_ASSERT_TRUE(cJSON_IsInt64Number(item));
+
+    item->type = cJSON_False;
+    TEST_ASSERT_FALSE(cJSON_IsInt64Number(item));
+}
+
+static void cjson_functions_should_not_crash_with_null_pointers_with_int64(void)
+{
+    cJSON *item = cJSON_CreateString("item");
+
+    TEST_ASSERT_FALSE(cJSON_IsInt64Number(NULL));
+    cJSON_AddInt64NumberToObject(NULL, "item", 0LL);
+    cJSON_AddInt64NumberToObject(item, NULL, 0LL);
+    cJSON_AddInt64NumberToObject(NULL, NULL, 0LL);
+    TEST_ASSERT_NULL(cJSON_GetInt64NumberValue(NULL));
+    TEST_ASSERT_EQUAL_INT64(0LL, cJSON_SetInt64NumberValue(NULL, 0LL));
+
+    cJSON_Delete(item);
+}
+
+static void cjson_get_number_value_should_get_a_number_with_int64(void)
+{
+    cJSON *string = cJSON_CreateString("test");
+    cJSON *number = cJSON_CreateInt64Number(1LL);
+
+    TEST_ASSERT_EQUAL_INT64(*cJSON_GetInt64NumberValue(number), number->valueint);
+    TEST_ASSERT_NULL(cJSON_GetInt64NumberValue(string));
+    TEST_ASSERT_NULL(cJSON_GetInt64NumberValue(NULL));
+
+    cJSON_Delete(number);
+    cJSON_Delete(string);
+}
+
+int CJSON_CDECL main(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(cjson_get_object_item_should_get_object_items_with_int64);
+    RUN_TEST(cjson_get_object_item_case_sensitive_should_get_object_items_with_int64);
+    RUN_TEST(cjson_set_number_value_should_set_numbers_with_int64);
+    RUN_TEST(typecheck_functions_should_check_type_with_int64);
+    RUN_TEST(cjson_functions_should_not_crash_with_null_pointers_with_int64);
+    RUN_TEST(cjson_get_number_value_should_get_a_number_with_int64);
+
+    return UNITY_END();
+}

--- a/tests/misc_tests.c
+++ b/tests/misc_tests.c
@@ -231,6 +231,15 @@ static void cjson_set_number_value_should_set_numbers(void)
     TEST_ASSERT_EQUAL(-1, number->valueint);
     TEST_ASSERT_EQUAL_DOUBLE(-1.5, number->valuedouble);
 
+#ifdef __CJSON_USE_INT64
+    cJSON_SetNumberValue(number, 1 + (double)LLONG_MAX);
+    TEST_ASSERT_EQUAL(LLONG_MAX, number->valueint);
+    TEST_ASSERT_EQUAL_DOUBLE(1 + (double)LLONG_MAX, number->valuedouble);
+
+    cJSON_SetNumberValue(number, -1 + (double)LLONG_MIN);
+    TEST_ASSERT_EQUAL(LLONG_MIN, number->valueint);
+    TEST_ASSERT_EQUAL_DOUBLE(-1 + (double)LLONG_MIN, number->valuedouble);
+#else
     cJSON_SetNumberValue(number, 1 + (double)INT_MAX);
     TEST_ASSERT_EQUAL(INT_MAX, number->valueint);
     TEST_ASSERT_EQUAL_DOUBLE(1 + (double)INT_MAX, number->valuedouble);
@@ -238,6 +247,7 @@ static void cjson_set_number_value_should_set_numbers(void)
     cJSON_SetNumberValue(number, -1 + (double)INT_MIN);
     TEST_ASSERT_EQUAL(INT_MIN, number->valueint);
     TEST_ASSERT_EQUAL_DOUBLE(-1 + (double)INT_MIN, number->valuedouble);
+#endif /* __CJSON_USE_INT64 */
 }
 
 static void cjson_detach_item_via_pointer_should_detach_items(void)

--- a/tests/print_number.c
+++ b/tests/print_number.c
@@ -24,6 +24,25 @@
 #include "unity/src/unity.h"
 #include "common.h"
 
+#ifdef __CJSON_USE_INT64
+static void assert_print_int64_number(const char *expected, long long input)
+{
+    unsigned char printed[1024];
+    cJSON item[1] = {{ NULL, NULL, NULL, cJSON_Number | cJSON_IsInt64, NULL, 0, 0, NULL }};
+    printbuffer buffer = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
+    buffer.buffer = printed;
+    buffer.length = sizeof(printed);
+    buffer.offset = 0;
+    buffer.noalloc = true;
+    buffer.hooks = global_hooks;
+
+    cJSON_SetInt64NumberValue(item, input);
+    TEST_ASSERT_TRUE_MESSAGE(print_number(item, &buffer), "Failed to print int64 number.");
+
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, buffer.buffer, "Printed int64 number is not as expected.");
+}
+#endif /* __CJSON_USE_INT64 */
+
 static void assert_print_number(const char *expected, double input)
 {
     unsigned char printed[1024];
@@ -72,6 +91,12 @@ static void print_number_should_print_negative_integers(void)
     assert_print_number("-1", -1.0);
     assert_print_number("-32768", -32768.0);
     assert_print_number("-2147483648", -2147483648.0);
+#ifdef __CJSON_USE_INT64
+    assert_print_int64_number("-1", -1LL);
+    assert_print_int64_number("-32768", -32768LL);
+    assert_print_int64_number("-2147483647", -2147483647LL);
+    assert_print_int64_number("-9223372036854775808", LLONG_MIN);
+#endif /* __CJSON_USE_INT64 */
 }
 
 static void print_number_should_print_positive_integers(void)
@@ -79,6 +104,12 @@ static void print_number_should_print_positive_integers(void)
     assert_print_number("1", 1.0);
     assert_print_number("32767", 32767.0);
     assert_print_number("2147483647", 2147483647.0);
+#ifdef __CJSON_USE_INT64
+    assert_print_int64_number("1", 1LL);
+    assert_print_int64_number("32767", 32767LL);
+    assert_print_int64_number("2147483647", 2147483647LL);
+    assert_print_int64_number("9223372036854775807", LLONG_MAX);
+#endif /* __CJSON_USE_INT64 */
 }
 
 static void print_number_should_print_positive_reals(void)


### PR DESCRIPTION
I have noticed there are several PRs about int64 support. However, they are modifying the existing code and change cjson from c89 to c99, which I think is not a good idea.
In this PR, I have added a new option `ENABLE_INT64`. By default, it's turned off, and cjson is still working in c89 without any differences. Only with `ENABLE_INT64` turned on, the int64 support will be enabled and c99 will be used.

Here are some details:

This commit adds int64 support for cjson. To enable int64, you need to define the macro `ENABLE_INT64`. To make it more clear, you need to build cjson like this:

```bash
mkdir build
cd build
cmake -DENABLE_INT64=ON ..
make
```

This implementation changed the type of `valueint` in `struct cJSON`: from `int` to `long long`(int64), and added a new flag `cJSON_IsInt64`.
For a int64 cJSON item, the value of `item->type` would be `cJSON_Number | cJSON_IsInt64`.

The existing functions `parse_number` and `print_number` can handle int64 now.

Considering I have added a new type `cJSON_IsInt64`, some new functions have been added:
```c
CJSON_PUBLIC(long long *) cJSON_GetInt64NumberValue(cJSON * const item)
CJSON_PUBLIC(cJSON_bool) cJSON_IsInt64Number(const cJSON * const item)
CJSON_PUBLIC(cJSON *) cJSON_CreateInt64Number(long long integer)
CJSON_PUBLIC(cJSON*) cJSON_AddInt64NumberToObject(cJSON * const object, const char * const name, const long long integer)
CJSON_PUBLIC(long long) cJSON_SetInt64NumberValue(cJSON * const object, const long long integer)
```

And some existing functions are also adjusted for int64, including `parse_number`, `cJSON_SetNumberHelper`, `print_number`, `cJSON_CreateNumber`, `cJSON_Compare` and `compare_json`(in cJSON_Utils).

Besides the code changes, we have also added some testcases for int64.
These tests will run if `ENABLE_INT64` is turned on.