### PR TITLE
simplify the use of *nix symbol exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,11 +88,11 @@ endif()
 option(ENABLE_PUBLIC_SYMBOLS "Export library symbols." On)
 if (ENABLE_PUBLIC_SYMBOLS)
     list(APPEND custom_compiler_flags -fvisibility=hidden)
-    add_definitions(-DCJSON_EXPORT_SYMBOLS -DCJSON_API_VISIBILITY)
+    add_definitions(-DCJSON_EXPORT_SYMBOLS)
 endif()
 option(ENABLE_HIDDEN_SYMBOLS "Hide library symbols." Off)
 if (ENABLE_HIDDEN_SYMBOLS)
-    add_definitions(-DCJSON_HIDE_SYMBOLS -UCJSON_API_VISIBILITY)
+    add_definitions(-DCJSON_HIDE_SYMBOLS)
 endif()
 
 # apply custom compiler flags

--- a/cJSON.h
+++ b/cJSON.h
@@ -48,8 +48,6 @@ or
 -xldscope=hidden (for sun cc)
 to CFLAGS
 
-then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJSON_EXPORT_SYMBOLS does
-
 */
 
 #define CJSON_CDECL __cdecl
@@ -71,7 +69,7 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 #define CJSON_CDECL
 #define CJSON_STDCALL
 
-#if (defined(__GNUC__) || defined(__SUNPRO_CC) || defined (__SUNPRO_C)) && defined(CJSON_API_VISIBILITY)
+#if (defined(__GNUC__) || defined(__SUNPRO_CC) || defined (__SUNPRO_C)) && !defined(CJSON_HIDE_SYMBOLS)
 #define CJSON_PUBLIC(type)   __attribute__((visibility("default"))) type
 #else
 #define CJSON_PUBLIC(type) type


### PR DESCRIPTION
It is generally never wrong to avoid setting the symbol visibility to default for public symbols. It is already checked for compilers that actually support the attribute.

The visibility define merely tells the compiler that the symbol is semantically an interface symbol. This is already the default for all symbols. The real purpose of the attribute is simply to override -fvisibility passed on the command line.

On *nix, you can set visibility for both shared and static libraries without harm anyway.

Despite this, respect the "hidden symbols" option. There's no actual use for creating a shared library without symbols, and it's essentially a no-op for static libraries, but in the static library case one might be including cJSON into another shared library, and not want to expose the cJSON symbols.

Therefore, make the header *directly* respect this option, rather than conditionalizing it on the CMakeLists.txt both setting the hidden symbols define *and* undefining the visibility define.