### PR TITLE
Added stdint.h include in cJSON.c as required by arm-none-eabi-gcc 11.3.1

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -40,6 +40,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <math.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <limits.h>
 #include <ctype.h>


### PR DESCRIPTION
Attempting to build cJSON.c with arm-none-eabi-gcc 11.3.1 fails because int16_t etc is defined in stdint.h but there is no #include <stdint.h>. 

Fix: Added #include <stdint.h> to cJSON.c