### PR TITLE
Consider the sparse warnings and __DBL_EPSILON__

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -58,6 +58,10 @@
 
 #include "cJSON.h"
 
+#ifndef __DBL_EPSILON__
+  #define __DBL_EPSILON__ 2.2204460492503131e-16
+#endif
+
 /* define our own boolean type */
 #ifdef true
 #undef true
@@ -1094,7 +1098,7 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return
 /* Parse an object - create a new root, and populate. */
 CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthOpts(const char *value, size_t buffer_length, const char **return_parse_end, cJSON_bool require_null_terminated)
 {
-    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    parse_buffer buffer = { NULL, 0, 0, 0, { NULL, NULL, NULL } };
     cJSON *item = NULL;
 
     /* reset error position */
@@ -1174,12 +1178,12 @@ fail:
 /* Default options for cJSON_Parse */
 CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value)
 {
-    return cJSON_ParseWithOpts(value, 0, 0);
+    return cJSON_ParseWithOpts(value, NULL, 0);
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_ParseWithLength(const char *value, size_t buffer_length)
 {
-    return cJSON_ParseWithLengthOpts(value, buffer_length, 0, 0);
+    return cJSON_ParseWithLengthOpts(value, buffer_length, NULL, 0);
 }
 
 #define cjson_min(a, b) (((a) < (b)) ? (a) : (b))
@@ -1261,7 +1265,7 @@ CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON *item)
 
 CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt)
 {
-    printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
+    printbuffer p = { NULL, 0, 0, 0, 0, 0, { NULL, NULL, NULL } };
 
     if (prebuffer < 0)
     {
@@ -1291,7 +1295,7 @@ CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON
 
 CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format)
 {
-    printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
+    printbuffer p = { NULL, 0, 0, 0, 0, 0, { NULL, NULL, NULL } };
 
     if ((length < 0) || (buffer == NULL))
     {


### PR DESCRIPTION
Some values expected to be initialized with NULL was being initialized with 0 triggering sparse warnings

Also `DBL_EPSILON` on Linux GCC depends on `__DBL_EPSILON__` causing trouble on compilation.