### PR TITLE
Fix a null pointer crash in cJSON_ReplaceItemViaPointer

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -2291,7 +2291,7 @@ CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON 
 
 CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement)
 {
-    if ((parent == NULL) || (replacement == NULL) || (item == NULL))
+    if ((parent == NULL) || (parent->child == NULL) || (replacement == NULL) || (item == NULL))
     {
         return false;
     }


### PR DESCRIPTION
If the parent passed in cJSON_ReplaceItemViaPointer has not a child, which means parent->child is null, a null pointer dereference crash will be happened inside cJSON_ReplaceItemViaPointer.

This commit adds the NULL check of `parent->child` beforehand to inform user such incorrect usage.

fixes: #725

Signed-off-by: hopper-vul <hopper.vul@gmail.com>