### PR TITLE
ESP32 allocate memory from external or internal

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -85,6 +85,15 @@
 #endif
 #endif
 
+/* define MALLOC_CAP_FROMWHERE to let ESP32 choose from where to allocate memory from in all related malloc, realloc and calloc cJSON functions */
+#ifdef ESP32
+#ifndef MALLOC_CAP_FROMWHERE
+#define MALLOC_CAP_FROMWHERE  MALLOC_CAP_DEFAULT
+// replace MALLOC_CAP_DEFAULT to use the best option to ESP32 allocation based on your use
+// MALLOC_CAP_SPIRAM is to use external ran
+#endif
+#endif
+
 typedef struct {
     const unsigned char *json;
     size_t position;
@@ -160,11 +169,15 @@ typedef struct internal_hooks
     void *(CJSON_CDECL *reallocate)(void *pointer, size_t size);
 } internal_hooks;
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER)||defined(ESP32)
 /* work around MSVC error C2322: '...' address of dllimport '...' is not static */
 static void * CJSON_CDECL internal_malloc(size_t size)
 {
-    return malloc(size);
+    #ifdef ESP32
+      return heap_caps_malloc(size,MALLOC_CAP_FROMWHERE  );  //external spiram
+    #else
+      return malloc(size);
+    #endif
 }
 static void CJSON_CDECL internal_free(void *pointer)
 {
@@ -172,7 +185,12 @@ static void CJSON_CDECL internal_free(void *pointer)
 }
 static void * CJSON_CDECL internal_realloc(void *pointer, size_t size)
 {
-    return realloc(pointer, size);
+    //
+    #ifdef ESP32
+      return heap_caps_realloc(pointer, size,MALLOC_CAP_FROMWHERE  );  //external spiram
+    #else
+      return realloc(pointer, size);
+    #endif
 }
 #else
 #define internal_malloc malloc
@@ -562,10 +580,10 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     {
         length = sprintf((char*)number_buffer, "null");
     }
-	else if(d == (double)item->valueint)
-	{
-		length = sprintf((char*)number_buffer, "%d", item->valueint);
-	}
+    else if(d == (double)item->valueint)
+  	{
+  		  length = sprintf((char*)number_buffer, "%d", item->valueint);
+  	}
     else
     {
         /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
@@ -2361,11 +2379,6 @@ static cJSON_bool replace_item_in_object(cJSON *object, const char *string, cJSO
         cJSON_free(replacement->string);
     }
     replacement->string = (char*)cJSON_strdup((const unsigned char*)string, &global_hooks);
-    if (replacement->string == NULL)
-    {
-        return false;
-    }
-
     replacement->type &= ~cJSON_StringIsConst;
 
     return cJSON_ReplaceItemViaPointer(object, get_object_item(object, string, case_sensitive), replacement);


### PR DESCRIPTION
Hi,

Currently on heavy or most used memory needed applications we need to allocate the memopry need to cJSON in external memory.

It is extremely necessary to patch the files to let us choose from which memory we want to use the memory from, in this case, using the heap_caps_malloc, heap_caps_realloc or heap_caps_calloc function with the flag  MALLOC_CAP_INTERNAL, MALLOC_CAP_DEFAULT or MALLOC_CAP_SPIRAM, or can have all the flags to be used on allocation.

Its could be a simple implement when look at the cJSON.c at internal_malloc and internal_realloc so, the return of allocation could be used!