### PR TITLE
fix strlen(null)

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -405,10 +405,13 @@ CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
     {
         return NULL;
     }
-    if (strlen(valuestring) <= strlen(object->valuestring))
+    if (object->valuestring != NULL)
     {
-        strcpy(object->valuestring, valuestring);
-        return object->valuestring;
+        if (strlen(valuestring) <= strlen(object->valuestring))
+        {
+            strcpy(object->valuestring, valuestring);
+            return object->valuestring;
+        }
     }
     copy = (char*) cJSON_strdup((const unsigned char*)valuestring, &global_hooks);
     if (copy == NULL)


### PR DESCRIPTION
When used in this way, it may cause errors : strlen(null) 

cJSON* json=  cJSON_CreateObject();
json->type = cJSON_String;
cJSON_SetValuestring(json,string);