### PR TITLE
upgrade clang to fix actions error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
     - name: install build dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install clang-8 valgrind
+        sudo apt-get install clang-14 valgrind
     - name: build and test
       shell: bash
       run: |


### PR DESCRIPTION
Actions builds are failing because clang-8 is failing to be installed. Upgrade clang-8 to clang-14 to fix this.