### PR TITLE
[fix]: Makefile dependency for target "shared"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,8 @@ $(UTILS_STATIC): $(UTILS_OBJ)
 $(CJSON_SHARED_VERSION): $(CJSON_OBJ)
 	$(CC) -shared -o $@ $< $(CJSON_SO_LDFLAG) $(LDFLAGS)
 #cJSON_Utils
-$(UTILS_SHARED_VERSION): $(UTILS_OBJ)
-	$(CC) -shared -o $@ $< $(CJSON_OBJ) $(UTILS_SO_LDFLAG) $(LDFLAGS)
+$(UTILS_SHARED_VERSION): $(UTILS_OBJ) $(CJSON_OBJ)
+	$(CC) -shared -o $@ $< $(UTILS_SO_LDFLAG) $(LDFLAGS)
 
 #objects
 #cJSON


### PR DESCRIPTION
Fixs a dependency error while compiling cjson using the Makefile with -j option.
Resolving issue https://github.com/DaveGamble/cJSON/issues/771