### PR TITLE
Also add custom compiler flags for AppleClang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(custom_compiler_flags)
 include(CheckCCompilerFlag)
 option(ENABLE_CUSTOM_COMPILER_FLAGS "Enables custom compiler flags" ON)
 if (ENABLE_CUSTOM_COMPILER_FLAGS)
-    if (("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang") OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU"))
+    if (("${CMAKE_C_COMPILER_ID}" MATCHES "Clang") OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU"))
         list(APPEND custom_compiler_flags
             -std=c89
             -pedantic


### PR DESCRIPTION
This project adds custom compiler flags when the compiler is "Clang" or "GNU" (gcc). Apple's version of Clang (which comes with Xcode and the Xcode command line tools on macOS) identifies itself not as "Clang" but "AppleClang" so before this PR it did not receive those custom flags.