### PR TITLE
modify the function cJSON_GetArraySize

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -1503,6 +1503,7 @@ static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buf
         {
             goto fail; /* failed to parse value */
         }
+        item->size++;
         buffer_skip_whitespace(input_buffer);
     }
     while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
@@ -1679,6 +1680,7 @@ static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_bu
         {
             goto fail; /* failed to parse value */
         }
+        item->size++;
         buffer_skip_whitespace(input_buffer);
     }
     while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
@@ -1835,17 +1837,9 @@ CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON *array)
         return 0;
     }
 
-    child = array->child;
-
-    while(child != NULL)
-    {
-        size++;
-        child = child->next;
-    }
-
     /* FIXME: Can overflow here. Cannot be fixed without breaking the API */
 
-    return (int)size;
+    return array->size;
 }
 
 static cJSON* get_array_item(const cJSON *array, size_t index)
@@ -1982,6 +1976,7 @@ static cJSON_bool add_item_to_array(cJSON *array, cJSON *item)
             array->child->prev = item;
         }
     }
+    array->size++;
 
     return true;
 }
@@ -2212,7 +2207,7 @@ CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const it
         /* last element */
         parent->child->prev = item->prev;
     }
-
+    parent->size--;
     /* make sure the detached item doesn't point anywhere anymore */
     item->prev = NULL;
     item->next = NULL;

--- a/cJSON.h
+++ b/cJSON.h
@@ -120,6 +120,8 @@ typedef struct cJSON
 
     /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
     char *string;
+    /* The item's size include object and array */
+    int size;
 } cJSON;
 
 typedef struct cJSON_Hooks


### PR DESCRIPTION
I have add a element called size in struct cJSON to record the object and the arry size. At same time I modified  the function ”cJSON_GetArraySize“ which return cJSON.size