### PR TITLE
fix fail to catch last backslash # 780

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -792,7 +792,7 @@ static cJSON_bool parse_string(cJSON * const item, parse_buffer * const input_bu
             /* is escape sequence */
             if (input_end[0] == '\\')
             {
-                if ((size_t)(input_end + 1 - input_buffer->content) >= input_buffer->length)
+                if ((size_t)(input_end + 1 - input_buffer->content) >= input_buffer->length - 1)
                 {
                     /* prevent buffer overflow when last input character is a backslash */
                     goto fail;


### PR DESCRIPTION
static cJSON_bool parse_string(cJSON * const item, parse_buffer * const input_buffer)
{
...
  // this does not work
  if ((size_t)(input_end + 1 - input_buffer->content) >= input_buffer->length)
  {
       /* prevent buffer overflow when last input character is a backslash */
        goto fail;
  }
...
}
![image](https://github.com/DaveGamble/cJSON/assets/12673303/8da41d30-1024-4d49-b98a-c95a97fabb3a)

As show above , when last input character is a backslash.The index of input_end is always input_buffer->length - 2.
So input_end + 1 - input_buffer->content >= input_buffer->length will never come true。

Maybe we should minus 1 in the right:
input_end + 1 - input_buffer->content >= input_buffer->length-1