### PR TITLE
Support non-BMP characters by printing them in `\u6789\uabcd` sequence.

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -651,7 +651,7 @@ static unsigned parse_hex4(const unsigned char * const input)
  * A literal can be one or two sequences of the form \uXXXX */
 static unsigned char utf16_literal_to_utf8(const unsigned char * const input_pointer, const unsigned char * const input_end, unsigned char **output_pointer)
 {
-    long unsigned int codepoint = 0;
+    long unsigned int codepoint = 0; // ! it must have at least 24 bits
     unsigned int first_code = 0;
     const unsigned char *first_sequence = input_pointer;
     unsigned char utf8_length = 0;
@@ -734,7 +734,7 @@ static unsigned char utf16_literal_to_utf8(const unsigned char * const input_poi
     }
     else if (codepoint <= 0x10FFFF)
     {
-        /* four bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx 10xxxxxx */
+        /* four bytes, encoding 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
         utf8_length = 4;
         first_byte_mark = 0xF0; /* 11110000 */
     }

--- a/tests/print_string.c
+++ b/tests/print_string.c
@@ -65,6 +65,11 @@ static void print_string_should_print_utf8(void)
     assert_print_string("\"ü猫慕\"", "ü猫慕");
 }
 
+static void print_string_should_print_utf16_surrogate_pairs(void)
+{
+    assert_print_string("\"\\ud801\\udc1d\\ud852\\udf62\"", "𐐝𤭢");
+}
+
 int CJSON_CDECL main(void)
 {
     /* initialize cJSON item */
@@ -73,6 +78,7 @@ int CJSON_CDECL main(void)
     RUN_TEST(print_string_should_print_empty_strings);
     RUN_TEST(print_string_should_print_ascii);
     RUN_TEST(print_string_should_print_utf8);
+    RUN_TEST(print_string_should_print_utf16_surrogate_pairs);
 
     return UNITY_END();
 }


### PR DESCRIPTION
feature: Support output non-BMP (Basic Multilingual Plane) characters.
Support them by printing them in `\u6789\uabcd` sequence.
This feature helps to fit latest standard RFC 8259.
Fixed Issue #783 

Related works:
doc: Add explaining sentences in README.md to highlight non-BMP support.
test: Add function `print_string_should_print_utf16_surrogate_pairs` to unit tests. (ALL 4/4 PASSED)

Side effects:
The first lines of README.md's (ToC) were modified by by markdown editor 😿 .