### PR TITLE
fix positive value with '+' prefix crash in parse_value()

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -1345,7 +1345,7 @@ static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buf
         return parse_string(item, input_buffer);
     }
     /* number */
-    if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9'))))
+    if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '+') || (buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9'))))
     {
         return parse_number(item, input_buffer);
     }

--- a/tests/parse_value.c
+++ b/tests/parse_value.c
@@ -73,6 +73,8 @@ static void parse_value_should_parse_false(void)
 static void parse_value_should_parse_number(void)
 {
     assert_parse_value("1.5", cJSON_Number);
+    assert_parse_value("+1.5", cJSON_Number);
+    assert_parse_value("-1.5", cJSON_Number);
     reset(item);
 }
 


### PR DESCRIPTION
without this fix, the program will crash with the following test:
`assert_parse_value("+1.5", cJSON_Number);`