### PR TITLE
misspelling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if (ENABLE_SANITIZERS)
         -fsanitize=float-cast-overflow
         -fsanitize-address-use-after-scope
         -fsanitize=integer
-        -01
+        -O1
         -fno-sanitize-recover
         )
 endif()


### PR DESCRIPTION
Instead of '01', it's 'O1'.
if (ENABLE_SANITIZERS)
    list(APPEND custom_compiler_flags
        -fno-omit-frame-pointer
        -fsanitize=address
        -fsanitize=undefined
        -fsanitize=float-cast-overflow
        -fsanitize-address-use-after-scope
        -fsanitize=integer
        -O1
        -fno-sanitize-recover
        )
endif()