### PR TITLE
fix strlen(null)

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -405,7 +405,7 @@ CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
     {
         return NULL;
     }
-    if (strlen(valuestring) <= strlen(object->valuestring))
+    if (object->valuestring && (strlen(valuestring) <= strlen(object->valuestring)))
     {
         strcpy(object->valuestring, valuestring);
         return object->valuestring;


### PR DESCRIPTION
When used in this way, it may cause errors : strlen(null)

cJSON* json= cJSON_CreateObject();
json->type = cJSON_String;
cJSON_SetValuestring(json,string);