### PR TITLE
Add support for publishing to Platform IO

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,26 @@
+{
+    "name": "cJSON",
+    "version": "1.7.16",
+    "description": "JSON parsing and serialization in ANSI C",
+    "keywords": "json, c",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/DaveGamble/cJSON"
+    },
+    "authors": [
+        {
+            "name": "Dave Gamble",
+            "maintainer": true
+        }
+    ],
+    "license": "MIT",
+    "frameworks": "*",
+    "platforms": "*",
+    "headers": ["cJSON.h", "cJSON_Utils.h"],
+    "build": {
+      "includeDir": ".",
+      "srcDir": ".",
+      "srcFilter": ["+<cJSON.c>", "+<cJSON_Utils.c"],
+      "libLDFMode": "off"
+    }
+  }


### PR DESCRIPTION
I wanted to add this library to the Platform IO library registry, I think this should be enough to make that possible. I tested it as much as I could without actually publishing it since I figure it would be better for someone active in this project to do that.