### PR TITLE
Fix indentation (should use spaces)

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -567,10 +567,10 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     {
         length = sprintf((char*)number_buffer, "null");
     }
-	else if(d == (double)item->valueint)
-	{
-		length = sprintf((char*)number_buffer, "%d", item->valueint);
-	}
+    else if(d == (double)item->valueint)
+    {
+        length = sprintf((char*)number_buffer, "%d", item->valueint);
+    }
     else
     {
         /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */


### PR DESCRIPTION
This was "broken" almost two years ago: https://github.com/DaveGamble/cJSON/commit/d321fa9e6e574ff93518f6384865b9af0a4a4afc

I just noticed it when updating cJSON 1.7.15 -> 1.7.17 in our project here and saw the indentation is off (we use the default GNU tabsize of 8):
![grafik](https://github.com/DaveGamble/cJSON/assets/16748619/98601e0e-1cb8-4fc1-8f7c-f0c260040b52)

https://github.com/pi-hole/FTL/pull/1843