### PR TITLE
add NULL checks to cJSON_DetachItemViaPointer()

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -2196,7 +2196,7 @@ CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const it
         return NULL;
     }
 
-    if (item != parent->child)
+    if (item != parent->child && item->prev != NULL)
     {
         /* not the first element */
         item->prev->next = item->next;
@@ -2212,7 +2212,7 @@ CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const it
         /* first element */
         parent->child = item->next;
     }
-    else if (item->next == NULL)
+    else if (item->next == NULL && parent->child != NULL)
     {
         /* last element */
         parent->child->prev = item->prev;


### PR DESCRIPTION
Add NULL checks to cJSON_DetachItemViaPointer() in case its input is incomplete, so to prevent unintentional crash.