### PR TITLE
Enable compatibility with Linux (and other) kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(ENABLE_CUSTOM_COMPILER_FLAGS "Enables custom compiler flags" ON)
 if (ENABLE_CUSTOM_COMPILER_FLAGS)
     if (("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang") OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU"))
         list(APPEND custom_compiler_flags
-            -std=c89
+            -std=c99
             -pedantic
             -Wall
             -Wextra

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,11 @@ if (ENABLE_HIDDEN_SYMBOLS)
     add_definitions(-DCJSON_HIDE_SYMBOLS -UCJSON_API_VISIBILITY)
 endif()
 
+option(NO_FLOATING_POINT "Build without Floating Foint support" OFF)
+if (NO_FLOATING_POINT)
+    add_definitions(-DNO_FLOATING_POINT)
+endif()
+
 # apply custom compiler flags
 foreach(compiler_flag ${custom_compiler_flags})
     #remove problematic characters
@@ -242,7 +247,7 @@ if(ENABLE_TARGET_EXPORT)
 endif()
 
 option(ENABLE_CJSON_TEST "Enable building cJSON test" ON)
-if(ENABLE_CJSON_TEST)
+if (ENABLE_CJSON_TEST AND (NOT NO_FLOATING_POINT))
     enable_testing()
 
     set(TEST_CJSON cJSON_test)
@@ -264,6 +269,8 @@ if(ENABLE_CJSON_TEST)
     add_custom_target(check
         COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
         DEPENDS ${TEST_CJSON})
+
+    add_subdirectory(tests)
 endif()
 
 #Create the uninstall target
@@ -279,5 +286,4 @@ if(ENABLE_LOCALES)
 	add_definitions(-DENABLE_LOCALES)
 endif()
 
-add_subdirectory(tests)
 add_subdirectory(fuzzing)

--- a/cJSON.c
+++ b/cJSON.c
@@ -124,7 +124,7 @@ CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item)
 CJSON_PUBLIC(const char*) cJSON_Version(void)
 {
     static char version[15];
-    sprintf(version, "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
+    snprintf(version, sizeof(version), "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
 
     return version;
 }
@@ -565,26 +565,26 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     /* This checks for NaN and Infinity */
     if (isnan(d) || isinf(d))
     {
-        length = sprintf((char*)number_buffer, "null");
+        length = snprintf((char*)number_buffer, sizeof(number_buffer), "null");
     }
 	else if(d == (double)item->valueint)
 	{
-		length = sprintf((char*)number_buffer, "%d", item->valueint);
+		length = snprintf((char*)number_buffer, sizeof(number_buffer), "%d", item->valueint);
 	}
     else
     {
         /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
-        length = sprintf((char*)number_buffer, "%1.15g", d);
+        length = snprintf((char*)number_buffer, sizeof(number_buffer), "%1.15g", d);
 
         /* Check whether the original double can be recovered */
         if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || !compare_double((double)test, d))
         {
             /* If not, print with 17 decimal places of precision */
-            length = sprintf((char*)number_buffer, "%1.17g", d);
+            length = snprintf((char*)number_buffer, sizeof(number_buffer), "%1.17g", d);
         }
     }
 
-    /* sprintf failed or buffer overrun occurred */
+    /* snprintf failed or buffer overrun occurred */
     if ((length < 0) || (length > (int)(sizeof(number_buffer) - 1)))
     {
         return false;
@@ -1013,8 +1013,7 @@ static cJSON_bool print_string_ptr(const unsigned char * const input, printbuffe
                     break;
                 default:
                     /* escape and print as unicode codepoint */
-                    sprintf((char*)output_pointer, "u%04x", *input_pointer);
-                    output_pointer += 4;
+                    output_pointer += snprintf((char*)output_pointer, 6, "u%04x", *input_pointer);
                     break;
             }
         }

--- a/cJSON.h
+++ b/cJSON.h
@@ -78,6 +78,16 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 #endif
 #endif
 
+#ifndef NO_FLOATING_POINT
+typedef double			Numeric;
+#define strtonum(s, num)	sscanf((s), "%lf", (num))
+
+#else
+
+typedef long			Numeric;
+#define strtonum(s, num)	sscanf((s), "%ld", (num))
+#endif
+
 /* project version */
 #define CJSON_VERSION_MAJOR 1
 #define CJSON_VERSION_MINOR 7
@@ -116,7 +126,7 @@ typedef struct cJSON
     /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
     int valueint;
     /* The item's number, if type==cJSON_Number */
-    double valuedouble;
+    Numeric valuedouble;
 
     /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
     char *string;
@@ -177,7 +187,7 @@ CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void);
 
 /* Check item type and return its value */
 CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item);
-CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item);
+CJSON_PUBLIC(Numeric) cJSON_GetNumberValue(const cJSON * const item);
 
 /* These functions check the type of an item */
 CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON * const item);
@@ -196,7 +206,7 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateNull(void);
 CJSON_PUBLIC(cJSON *) cJSON_CreateTrue(void);
 CJSON_PUBLIC(cJSON *) cJSON_CreateFalse(void);
 CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool boolean);
-CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num);
+CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(Numeric num);
 CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string);
 /* raw json */
 CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw);
@@ -214,8 +224,10 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child);
 /* These utilities create an Array of count items.
  * The parameter count cannot be greater than the number of elements in the number array, otherwise array access will be out of bounds.*/
 CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count);
+#ifndef NO_FLOATING_POINT
 CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count);
 CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count);
+#endif
 CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char *const *strings, int count);
 
 /* Append item to the specified array/object. */
@@ -265,7 +277,7 @@ CJSON_PUBLIC(cJSON*) cJSON_AddNullToObject(cJSON * const object, const char * co
 CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObject(cJSON * const object, const char * const name);
 CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * const name);
 CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean);
-CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number);
+CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const Numeric number);
 CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
 CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw);
 CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name);
@@ -274,8 +286,8 @@ CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * c
 /* When assigning an integer value, it needs to be propagated to valuedouble too. */
 #define cJSON_SetIntValue(object, number) ((object) ? (object)->valueint = (object)->valuedouble = (number) : (number))
 /* helper for the cJSON_SetNumberValue macro */
-CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number);
-#define cJSON_SetNumberValue(object, number) ((object != NULL) ? cJSON_SetNumberHelper(object, (double)number) : (number))
+CJSON_PUBLIC(Numeric) cJSON_SetNumberHelper(cJSON *object, Numeric number);
+#define cJSON_SetNumberValue(object, number) ((object != NULL) ? cJSON_SetNumberHelper(object, (Numeric)number) : (number))
 /* Change the valuestring of a cJSON_String object, only takes effect when type of object is cJSON_String */
 CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring);
 

--- a/cJSON.h
+++ b/cJSON.h
@@ -78,6 +78,10 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 #endif
 #endif
 
+#ifdef __KERNEL__
+#define NO_FLOATING_POINT
+#endif
+
 #ifndef NO_FLOATING_POINT
 typedef double			Numeric;
 #define strtonum(s, num)	sscanf((s), "%lf", (num))
@@ -93,7 +97,13 @@ typedef long			Numeric;
 #define CJSON_VERSION_MINOR 7
 #define CJSON_VERSION_PATCH 17
 
+#ifdef __KERNEL__
+#include <linux/types.h>
+
+#else
+
 #include <stddef.h>
+#endif
 
 /* cJSON Types: */
 #define cJSON_Invalid (0)


### PR DESCRIPTION
The purpose of this PR is to enable using cJSON in the kernel space, in particular Linux kernel.  
This requirement has 3 consequences:  
- no floating point numbers  
- Linux-specific header files  
- refrain from using insecure functions (sprintf())  

When building as a part of Linux kernel code, the __KERNEL__ macro will be recognized automatically.  
In order to build with no floating point numbers, introduce NO_FLOATING_POINT macro. This macro is automatically introduced in case __KERNEL__ is present.  

This PR strives to keep all the existing functionality unchanged.