### PR TITLE
Add NULL check to cJSON_SetValuestring()

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -406,7 +406,7 @@ CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
         return NULL;
     }
     /* return NULL if the object is corrupted */
-    if (object->valuestring == NULL)
+    if (object->valuestring == NULL || valuestring == NULL)
     {
         return NULL;
     }


### PR DESCRIPTION
If the valuestring passed to cJSON_SetValuestring is NULL, a null pointer dereference will happen.

This commit adds the NULL check of valuestring before it is dereferenced.

fixes: #839