### PR TITLE
Fix spelling errors found by CodeSpell. 

### DIFF
--- a/tests/cjson_add.c
+++ b/tests/cjson_add.c
@@ -34,7 +34,7 @@ static void * CJSON_CDECL failing_malloc(size_t size)
     return NULL;
 }
 
-/* work around MSVC error C2322: '...' address of dillimport '...' is not static */
+/* work around MSVC error C2322: '...' address of dllimport '...' is not static */
 static void CJSON_CDECL normal_free(void *pointer)
 {
     free(pointer);

--- a/tests/print_object.c
+++ b/tests/print_object.c
@@ -63,7 +63,7 @@ static void assert_print_object(const char * const expected, const char * const 
 
     formatted_buffer.format = true;
     TEST_ASSERT_TRUE_MESSAGE(print_object(item, &formatted_buffer), "Failed to print formatted string.");
-    TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, printed_formatted, "Formatted ojbect is not correct.");
+    TEST_ASSERT_EQUAL_STRING_MESSAGE(expected, printed_formatted, "Formatted object is not correct.");
 
     reset(item);
 }

--- a/tests/unity/auto/parse_output.rb
+++ b/tests/unity/auto/parse_output.rb
@@ -78,7 +78,7 @@ class ParseOutput
     @array_list.push '     <testcase classname="' + test_suite + '" name="' + test_name + '"/>'
   end
 
-  # Test was flagged as being ingored so format the output
+  # Test was flagged as being ignored so format the output
   def test_ignored(array)
     last_item = array.length - 1
     test_name = array[last_item - 2]

--- a/tests/unity/docs/UnityGettingStartedGuide.md
+++ b/tests/unity/docs/UnityGettingStartedGuide.md
@@ -72,7 +72,7 @@ header files. These three files _are_ Unity.
 into this folder already. This is where all the handy documentation can be
 found.
 - `examples` - This contains a few examples of using Unity.
-- `extras` - These are optional add ons to Unity that are not part of the core
+- `extras` - These are optional addons to Unity that are not part of the core
 project. If you've reached us through James Grenning's book, you're going to
 want to look here.
 - `test` - This is how Unity and its scripts are all tested. If you're just using

--- a/tests/unity/extras/eclipse/error_parsers.txt
+++ b/tests/unity/extras/eclipse/error_parsers.txt
@@ -2,7 +2,7 @@ Eclipse error parsers
 =====================
 
 These are a godsend for extracting  & quickly navigating to
-warnings & error messages from console output. Unforunately
+warnings & error messages from console output. Unfortunately
 I don't know how to write an Eclipse plugin so you'll have
 to add them manually.
 

--- a/tests/unity/src/unity.c
+++ b/tests/unity/src/unity.c
@@ -8,7 +8,7 @@
 #include "unity.h"
 #include <stddef.h>
 
-/* If omitted from header, declare overrideable prototypes here so they're ready for use */
+/* If omitted from header, declare overridable prototypes here so they're ready for use */
 #ifdef UNITY_OMIT_OUTPUT_CHAR_HEADER_DECLARATION
 void UNITY_OUTPUT_CHAR(int);
 #endif

--- a/tests/unity/test/rakefile
+++ b/tests/unity/test/rakefile
@@ -26,7 +26,7 @@ task :prepare_for_tests => TEMP_DIRS
 
 include RakefileHelpers
 
-# Load proper GCC as defult configuration
+# Load proper GCC as default configuration
 DEFAULT_CONFIG_FILE = 'gcc_auto_stdint.yml'
 configure_toolchain(DEFAULT_CONFIG_FILE)
 


### PR DESCRIPTION
This PR fixes a handful of typos and misspellings found by the CodeSpell utility, which lives at https://github.com/codepell-project/codespell

Other than a single corrected test failure output string, there are no functional changes.