### PR TITLE
fix: fix NULL valuestring error

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -406,8 +406,15 @@ CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
         return NULL;
     }
     /* return NULL if the object is corrupted */
-    if (object->valuestring == NULL || valuestring == NULL)
+    if (object->valuestring == NULL)
     {
+        return NULL;
+    }
+    /* NULL valuestring causes error with strlen and should be treated separately */
+    if (valuestring == NULL)
+    {
+        cJSON_free(object->valuestring);
+        object->valuestring = NULL;
         return NULL;
     }
     if (strlen(valuestring) <= strlen(object->valuestring))

--- a/tests/misc_tests.c
+++ b/tests/misc_tests.c
@@ -444,6 +444,7 @@ static void cjson_functions_should_not_crash_with_null_pointers(void)
     TEST_ASSERT_FALSE(cJSON_Compare(NULL, item, false));
     TEST_ASSERT_NULL(cJSON_SetValuestring(NULL, "test"));
     TEST_ASSERT_NULL(cJSON_SetValuestring(corruptedString, "test"));
+    TEST_ASSERT_NULL(cJSON_SetValuestring(item, NULL));
     cJSON_Minify(NULL);
     /* skipped because it is only used via a macro that checks for NULL */
     /* cJSON_SetNumberHelper(NULL, 0); */


### PR DESCRIPTION
Fix NULL valuestring problem in cJSON_SetValuestring. This fixes #839 and CVE-2024-31755
Related issue #845