### PR TITLE
Remove non-functional list handling of compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,12 +102,9 @@ foreach(compiler_flag ${custom_compiler_flags})
 
     CHECK_C_COMPILER_FLAG(${compiler_flag} "FLAG_SUPPORTED_${current_variable}")
     if (FLAG_SUPPORTED_${current_variable})
-        list(APPEND supported_compiler_flags)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${compiler_flag}")
     endif()
 endforeach()
-
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${supported_compiler_flags}")
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(ENABLE_TARGET_EXPORT "Enable exporting of CMake targets. Disable when it causes problems!" ON)


### PR DESCRIPTION
The list append operation is a no-op. The line right below it is already doing the intended work.