### PR TITLE
Fix heap buffer overflow

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -1660,6 +1660,11 @@ static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_bu
             current_item = new_item;
         }
 
+        if (cannot_access_at_index(input_buffer, 1))
+        {
+            goto fail; /* nothing comes after the comma */
+        }
+
         /* parse the name of the child */
         input_buffer->offset++;
         buffer_skip_whitespace(input_buffer);

--- a/tests/parse_examples.c
+++ b/tests/parse_examples.c
@@ -250,6 +250,33 @@ static void test14_should_not_be_parsed(void)
     }
 }
 
+/* Address Sanitizer */
+static void test15_should_not_heap_buffer_overflow(void)
+{
+    const char *strings[] = {
+        "{\"1\":1,",
+        "{\"1\":1, ",
+    };
+
+    size_t i;
+
+    for (i = 0; i < sizeof(strings) / sizeof(strings[0]); i+=1)
+    {
+        const char *json_string = strings[i];
+        size_t len = strlen(json_string);
+        cJSON *json = NULL;
+
+        char *exact_size_heap = (char*)malloc(len);
+        TEST_ASSERT_NOT_NULL(exact_size_heap);
+
+        memcpy(exact_size_heap, json_string, len);
+        json = cJSON_ParseWithLength(exact_size_heap, len);
+
+        cJSON_Delete(json);
+        free(exact_size_heap);
+    }
+}
+
 int CJSON_CDECL main(void)
 {
     UNITY_BEGIN();
@@ -267,5 +294,6 @@ int CJSON_CDECL main(void)
     RUN_TEST(test12_should_not_be_parsed);
     RUN_TEST(test13_should_be_parsed_without_null_termination);
     RUN_TEST(test14_should_not_be_parsed);
+    RUN_TEST(test15_should_not_heap_buffer_overflow);
     return UNITY_END();
 }


### PR DESCRIPTION
Fixes #800 

Note that I have a kernel bug which makes ASan fail when address layout randomization is enabled. On top of that, CMake's CHECK_C_COMPILER_FLAG for some reason returns false on my machine for the address sanitizer (among others). So it's a bit of a bother testing this, but I did do so. I just had to force the address sanitizer to be on and disable address layout randomization. Someone else can perhaps test the new test normally, with and without the fix.

I hope the style of test is fine. It's meant to catch the issue when the address sanitizer is enabled. It will simply pass, or at least likely to, if the sanitizer is off.

The first string in the test is the actual string which triggers the bug. The second doesn't, but protects against future bugs in the surrounding area. More strings can be added with ease.