### PR TITLE
Copy object item key to replacement in ReplaceItemViaPointer

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -2327,6 +2327,22 @@ CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON
     replacement->next = item->next;
     replacement->prev = item->prev;
 
+    if (item->string)
+    {
+        /* duplicate name from source to replacement */
+        if (!(replacement->type & cJSON_StringIsConst) && (replacement->string != NULL))
+        {
+            cJSON_free(replacement->string);
+        }
+        replacement->string = (char*)cJSON_strdup((const unsigned char*)item->string, &global_hooks);
+        if (replacement->string == NULL)
+        {
+            return false;
+        }
+
+        replacement->type &= ~cJSON_StringIsConst;
+    }
+
     if (replacement->next != NULL)
     {
         replacement->next->prev = replacement;
@@ -2377,19 +2393,6 @@ static cJSON_bool replace_item_in_object(cJSON *object, const char *string, cJSO
     {
         return false;
     }
-
-    /* replace the name in the replacement */
-    if (!(replacement->type & cJSON_StringIsConst) && (replacement->string != NULL))
-    {
-        cJSON_free(replacement->string);
-    }
-    replacement->string = (char*)cJSON_strdup((const unsigned char*)string, &global_hooks);
-    if (replacement->string == NULL)
-    {
-        return false;
-    }
-
-    replacement->type &= ~cJSON_StringIsConst;
 
     return cJSON_ReplaceItemViaPointer(object, get_object_item(object, string, case_sensitive), replacement);
 }

--- a/tests/misc_tests.c
+++ b/tests/misc_tests.c
@@ -345,6 +345,16 @@ static void cjson_replace_item_in_object_should_preserve_name(void)
     TEST_ASSERT_TRUE(root->child == replacement);
     TEST_ASSERT_EQUAL_STRING("child", replacement->string);
 
+    // now test the same, but with replaceitemviapointer
+    child = cJSON_GetObjectItemCaseSensitive(root, "child");
+    TEST_ASSERT_NOT_NULL(child);
+    replacement = cJSON_CreateNumber(3);
+    TEST_ASSERT_NOT_NULL(replacement);
+    cJSON_ReplaceItemViaPointer(root, child, replacement);
+
+    TEST_ASSERT_TRUE(root->child == replacement);
+    TEST_ASSERT_EQUAL_STRING("child", replacement->string);
+
     cJSON_Delete(replacement);
 }
 

--- a/tests/misc_tests.c
+++ b/tests/misc_tests.c
@@ -345,7 +345,7 @@ static void cjson_replace_item_in_object_should_preserve_name(void)
     TEST_ASSERT_TRUE(root->child == replacement);
     TEST_ASSERT_EQUAL_STRING("child", replacement->string);
 
-    // now test the same, but with replaceitemviapointer
+    /* now test the same, but with replaceitemviapointer */
     child = cJSON_GetObjectItemCaseSensitive(root, "child");
     TEST_ASSERT_NOT_NULL(child);
     replacement = cJSON_CreateNumber(3);


### PR DESCRIPTION
README indicates that object items can be replaced with `cJSON_ReplaceItemViaPointer`. However, the key for an object item will be lost in that process, unless the caller uses information on cJSON internals to update the replacement object's key with that of the source. `cJSON_ReplaceItemInObject` is listed as the other method for replacing an object item, and does set the key on the replacement value.
This PR updates `cJSON_ReplaceItemViaPointer` to copy any string on the item to be replaced with that of the source.
Consideration was made to just reuse the string from the item being replaced - opted to effectively replicate the existing functionality of `cJSON_ReplaceItemInObject`, which always allocated a new string for key.

Example:
```
	cJSON *j, *r, *t;
	j = cJSON_Parse("{\"foo\": \"bar\"}");
	r = cJSON_Parse("{\"bar\": true}");
	
	t = cJSON_GetObjectItemCaseSensitive(j, "foo");
	cJSON_ReplaceItemViaPointer(j, t, r);
	puts(cJSON_Print(j));
```
Under `master`, this prints:
```
{
	"":	{
		"bar":	true
	}
}
```
After this PR:
```
{
	"foo":	{
		"bar":	true
	}
}
```
Couldn't find contributor guidelines at a glance, so let me know if there are any other specifics needed here.