### PR TITLE
to avoid gcc -Werror=float-equal error

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -570,7 +570,7 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     {
         length = sprintf((char*)number_buffer, "null");
     }
-    else if(d == (double)item->valueint)
+    else if (compare_double(d, (double)item->valueint))
     {
         length = sprintf((char*)number_buffer, "%d", item->valueint);
     }


### PR DESCRIPTION
Hi Haven't found ohter way that is compatible with all compiler to avoid float-equal gcc error