### PR TITLE
Enforce sscanf-function return value check at print_number-function

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -580,7 +580,12 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
         length = sprintf((char*)number_buffer, "%1.15g", d);
 
         /* Check whether the original double can be recovered */
-        if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || !compare_double((double)test, d))
+        if (sscanf((char*)number_buffer, "%lg", &test) != 1)
+        {
+            return false;
+        }
+
+        if (!compare_double((double)test, d))
         {
             /* If not, print with 17 decimal places of precision */
             length = sprintf((char*)number_buffer, "%1.17g", d);


### PR DESCRIPTION
`print_number`-function acknowledge `sscanf`-function return value, but no actions are taken.

#### Test
Executed `make test` and all tests are passing.