### PR TITLE
Check for NULL in cJSON_DetachItemViaPointer, fixes #882

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -2204,7 +2204,7 @@ CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * c
 
 CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item)
 {
-    if ((parent == NULL) || (parent->child == NULL) || (item == NULL) || (item->prev == NULL))
+    if ((parent == NULL) || (item == NULL) || (item != parent->child && item->prev == NULL))
     {
         return NULL;
     }

--- a/cJSON.c
+++ b/cJSON.c
@@ -2204,7 +2204,7 @@ CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * c
 
 CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item)
 {
-    if ((parent == NULL) || (item == NULL))
+    if ((parent == NULL) || (parent->child == NULL) || (item == NULL) || (item->prev == NULL))
     {
         return NULL;
     }

--- a/tests/misc_tests.c
+++ b/tests/misc_tests.c
@@ -280,6 +280,21 @@ static void cjson_detach_item_via_pointer_should_detach_items(void)
     TEST_ASSERT_NULL_MESSAGE(parent->child, "Child of the parent wasn't set to NULL.");
 }
 
+static void cjson_detach_item_via_pointer_should_return_null_if_item_prev_is_null(void)
+{
+    cJSON list[2];
+    cJSON parent[1];
+
+    memset(list, '\0', sizeof(list));
+
+    /* link the list */
+    list[0].next = &(list[1]);
+
+    parent->child = &list[0];
+    TEST_ASSERT_NULL_MESSAGE(cJSON_DetachItemViaPointer(parent, &(list[1])), "Failed to detach in the middle.");
+    TEST_ASSERT_TRUE_MESSAGE(cJSON_DetachItemViaPointer(parent, &(list[0])) == &(list[0]), "Failed to detach in the middle.");
+}
+
 static void cjson_replace_item_via_pointer_should_replace_items(void)
 {
     cJSON replacements[3];
@@ -746,6 +761,7 @@ int CJSON_CDECL main(void)
     RUN_TEST(cjson_should_not_parse_to_deeply_nested_jsons);
     RUN_TEST(cjson_set_number_value_should_set_numbers);
     RUN_TEST(cjson_detach_item_via_pointer_should_detach_items);
+    RUN_TEST(cjson_detach_item_via_pointer_should_return_null_if_item_prev_is_null);
     RUN_TEST(cjson_replace_item_via_pointer_should_replace_items);
     RUN_TEST(cjson_replace_item_in_object_should_preserve_name);
     RUN_TEST(cjson_functions_should_not_crash_with_null_pointers);


### PR DESCRIPTION
I added two NULL check to avoid NULL dereferences in cJSON_DetachItemViaPointer as discussed in #882.

Once again, all credit goes to @tregua87