### PR TITLE
Fix compile fail with android ndk 27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6.0)
 
 project(cJSON
     VERSION 1.7.18


### PR DESCRIPTION
Compile error information:

CMake Warning (dev) at /data/android-sdk/ndk/27.0.12077973/build/cmake/flags.cmake:46 (if):
  Policy CMP0057 is not set: Support new IN_LIST if() operator.  Run "cmake
  --help-policy CMP0057" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  IN_LIST will be interpreted as an operator when the policy is set to NEW.
  Since the policy is not set the OLD behavior will be used.
Call Stack (most recent call first):
  /home/l/Downloads/cmake-3.30.2/share/cmake-3.30/Modules/Platform/Android-Clang.cmake:23 (include)
  /home/l/Downloads/cmake-3.30.2/share/cmake-3.30/Modules/Platform/Android-Clang-C.cmake:1 (include)
  /home/l/Downloads/cmake-3.30.2/share/cmake-3.30/Modules/CMakeCInformation.cmake:48 (include)
  CMakeLists.txt:4 (project)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at /data/android-sdk/ndk/27.0.12077973/build/cmake/flags.cmake:46 (if):
  if given arguments:

    "hwaddress" "IN_LIST" "ANDROID_SANITIZE"

  Unknown arguments specified
Call Stack (most recent call first):
  /home/l/Downloads/cmake-3.30.2/share/cmake-3.30/Modules/Platform/Android-Clang.cmake:23 (include)
  /home/l/Downloads/cmake-3.30.2/share/cmake-3.30/Modules/Platform/Android-Clang-C.cmake:1 (include)
  /home/l/Downloads/cmake-3.30.2/share/cmake-3.30/Modules/CMakeCInformation.cmake:48 (include)
  CMakeLists.txt:4 (project)