### PR TITLE
Fix #880 Max recursion depth for cJSON_Duplicate to prevent stack exhaustion

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -2726,7 +2726,14 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char *const *strings, int co
 }
 
 /* Duplication */
+cJSON * cJSON_Duplicate_rec(const cJSON *item, size_t depth, cJSON_bool recurse);
+
 CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse)
+{
+    return cJSON_Duplicate_rec(item, 0, recurse );
+}
+
+cJSON * cJSON_Duplicate_rec(const cJSON *item, size_t depth, cJSON_bool recurse)
 {
     cJSON *newitem = NULL;
     cJSON *child = NULL;
@@ -2773,7 +2780,10 @@ CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse)
     child = item->child;
     while (child != NULL)
     {
-        newchild = cJSON_Duplicate(child, true); /* Duplicate (with recurse) each item in the ->next chain */
+        if(depth >= CJSON_CIRCULAR_LIMIT) {
+            goto fail;
+        }
+        newchild = cJSON_Duplicate_rec(child, ++depth, true); /* Duplicate (with recurse) each item in the ->next chain */
         if (!newchild)
         {
             goto fail;

--- a/cJSON.c
+++ b/cJSON.c
@@ -2783,7 +2783,7 @@ cJSON * cJSON_Duplicate_rec(const cJSON *item, size_t depth, cJSON_bool recurse)
         if(depth >= CJSON_CIRCULAR_LIMIT) {
             goto fail;
         }
-        newchild = cJSON_Duplicate_rec(child, ++depth, true); /* Duplicate (with recurse) each item in the ->next chain */
+        newchild = cJSON_Duplicate_rec(child, depth + 1, true); /* Duplicate (with recurse) each item in the ->next chain */
         if (!newchild)
         {
             goto fail;

--- a/cJSON.h
+++ b/cJSON.h
@@ -137,6 +137,12 @@ typedef int cJSON_bool;
 #define CJSON_NESTING_LIMIT 1000
 #endif
 
+/* Limits the length of circular references can be before cJSON rejects to parse them.
+ * This is to prevent stack overflows. */
+#ifndef CJSON_CIRCULAR_LIMIT
+#define CJSON_CIRCULAR_LIMIT 10000
+#endif
+
 /* returns the version of cJSON as a string */
 CJSON_PUBLIC(const char*) cJSON_Version(void);
 

--- a/tests/misc_tests.c
+++ b/tests/misc_tests.c
@@ -219,6 +219,23 @@ static void cjson_should_not_parse_to_deeply_nested_jsons(void)
     TEST_ASSERT_NULL_MESSAGE(cJSON_Parse(deep_json), "To deep JSONs should not be parsed.");
 }
 
+static void cjson_should_not_follow_too_deep_circular_references(void)
+{
+    cJSON *o = cJSON_CreateArray();
+    cJSON *a = cJSON_CreateArray();
+    cJSON *b = cJSON_CreateArray();
+    cJSON *x;
+
+    cJSON_AddItemToArray(o, a);
+    cJSON_AddItemToArray(a, b);
+    cJSON_AddItemToArray(b, o);
+
+    x = cJSON_Duplicate(o, 1);
+    TEST_ASSERT_NULL(x);
+    cJSON_DetachItemFromArray(b, 0);
+    cJSON_Delete(o);
+}
+
 static void cjson_set_number_value_should_set_numbers(void)
 {
     cJSON number[1] = {{NULL, NULL, NULL, cJSON_Number, NULL, 0, 0, NULL}};
@@ -744,6 +761,7 @@ int CJSON_CDECL main(void)
     RUN_TEST(cjson_get_object_item_case_sensitive_should_not_crash_with_array);
     RUN_TEST(typecheck_functions_should_check_type);
     RUN_TEST(cjson_should_not_parse_to_deeply_nested_jsons);
+    RUN_TEST(cjson_should_not_follow_too_deep_circular_references);
     RUN_TEST(cjson_set_number_value_should_set_numbers);
     RUN_TEST(cjson_detach_item_via_pointer_should_detach_items);
     RUN_TEST(cjson_replace_item_via_pointer_should_replace_items);


### PR DESCRIPTION
Dear maintainers, 

Here is a suggestion of a fix to prevent the stack exhaustion in case of circular reference.

I duplicated the `cJSON_Duplicate` so that it could take a `depth` argument. This one is compared to `CJSON_CIRCULAR_LIMIT` which is currently set to `10'000` but likely need adaption based on your knowledge of what is use in practice. 

I also added a test under `cjson_should_not_follow_too_deep_circular_references`. 

If you don't like the extra function `cJSON_Duplicate_rec`, this fix could also be implemented through an additional field in the `cJSON` struct (likely break the ABI?) or through a global variable (making cJSON more thread unsafe). 

## What is not yet fixed
In addition to `cJSON_Duplicate`, the same issue happens in `cJSON_Delete`. I have a similar fix for it too but I'm unsure on what to do once we reach  `CJSON_CIRCULAR_LIMIT`. Aborting or exiting looks like the correct solution as it is likely that memory corruption occurred through a double free. 

What would you suggest to do in this case?