### PR TITLE
Feature to format floating point numbers

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -598,7 +598,7 @@ static void remove_trailing_zeros(char *str) {
     }
     /* Check if zero */
     start = str + is_neg;
-    while (start != end && *str == '0') {
+    while (start != end && *start == '0') {
         start++;
     }
     /* Discard negative sign if zero */
@@ -649,7 +649,7 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
         if (item->type & cJSON_NumberFormatStyleFixedPoint) {
             length = sprintf((char*)number_buffer, "%.*f", (int)precision, d);
             remove_trailing_zeros((char*)number_buffer);
-            length = strlen((char*)number_buffer);
+            length = (int)strlen((char*)number_buffer);
         } else {
             length = sprintf((char*)number_buffer, "%.*g", (int)precision, d);
         }

--- a/cJSON.c
+++ b/cJSON.c
@@ -444,6 +444,10 @@ CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
 
 CJSON_PUBLIC(void) cJSON_SetNumberFormat(cJSON *object, cJSON_bool g_format, int precision)
 {
+    if (object == NULL)
+    {
+        return;
+    }
     if ((object->type != cJSON_Number) && precision < 0)
     {
         return;

--- a/cJSON.c
+++ b/cJSON.c
@@ -19,7 +19,6 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-/* clang-format off */
 /* cJSON */
 /* JSON parser in C. */
 
@@ -599,7 +598,6 @@ static void remove_trailing_zeros(char *str) {
     }
     /* Check if zero */
     start = str + is_neg;
-    printf("start: %s\n", start);
     while (start != end && *str == '0') {
         start++;
     }
@@ -648,8 +646,6 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     }
     else if (item->type & cJSON_NumberIsFormatted) {
         precision = _get_precision_from_item(item, sizeof(number_buffer));
-        printf("precision: %d\n", precision);
-        printf("Style: %d\n", (item->type & cJSON_NumberFormatStyleFixedPoint));
         if (item->type & cJSON_NumberFormatStyleFixedPoint) {
             length = sprintf((char*)number_buffer, "%.*f", (int)precision, d);
             remove_trailing_zeros((char*)number_buffer);

--- a/cJSON.c
+++ b/cJSON.c
@@ -649,6 +649,7 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
         if (item->type & cJSON_NumberFormatStyleFixedPoint) {
             length = sprintf((char*)number_buffer, "%.*f", (int)precision, d);
             remove_trailing_zeros((char*)number_buffer);
+            length = strlen((char*)number_buffer);
         } else {
             length = sprintf((char*)number_buffer, "%.*g", (int)precision, d);
         }

--- a/cJSON.c
+++ b/cJSON.c
@@ -638,20 +638,20 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     /* This checks for NaN and Infinity */
     if (isnan(d) || isinf(d))
     {
-        length = sprintf((char*)number_buffer, "null");
+        length = snprintf((char*)number_buffer, sizeof(number_buffer), "null");
     }
     else if(d == (double)item->valueint)
     {
-        length = sprintf((char*)number_buffer, "%d", item->valueint);
+        length = snprintf((char*)number_buffer, sizeof(number_buffer), "%d", item->valueint);
     }
     else if (item->type & cJSON_NumberIsFormatted) {
         precision = _get_precision_from_item(item, sizeof(number_buffer));
         if (item->type & cJSON_NumberFormatStyleFixedPoint) {
-            length = sprintf((char*)number_buffer, "%.*f", (int)precision, d);
+            length = snprintf((char*)number_buffer, sizeof(number_buffer), "%.*f", (int)precision, d);
             remove_trailing_zeros((char*)number_buffer);
             length = (int)strlen((char*)number_buffer);
         } else {
-            length = sprintf((char*)number_buffer, "%.*g", (int)precision, d);
+            length = snprintf((char*)number_buffer, sizeof(number_buffer), "%.*g", (int)precision, d);
         }
     }
     else

--- a/cJSON.h
+++ b/cJSON.h
@@ -19,7 +19,7 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-
+/* clang-format off */
 #ifndef cJSON__h
 #define cJSON__h
 
@@ -87,17 +87,28 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 
 /* cJSON Types: */
 #define cJSON_Invalid (0)
-#define cJSON_False  (1 << 0)
-#define cJSON_True   (1 << 1)
-#define cJSON_NULL   (1 << 2)
-#define cJSON_Number (1 << 3)
-#define cJSON_String (1 << 4)
-#define cJSON_Array  (1 << 5)
-#define cJSON_Object (1 << 6)
-#define cJSON_Raw    (1 << 7) /* raw json */
+#define cJSON_False   (1 << 0)
+#define cJSON_True    (1 << 1)
+#define cJSON_NULL    (1 << 2)
+#define cJSON_Number  (1 << 3)
+#define cJSON_String  (1 << 4)
+#define cJSON_Array   (1 << 5)
+#define cJSON_Object  (1 << 6)
+#define cJSON_Raw     (1 << 7) /* raw json */
 
-#define cJSON_IsReference 256
-#define cJSON_StringIsConst 512
+#define cJSON_IsReference   (1 << 8)
+#define cJSON_StringIsConst (1 << 9)
+
+#define cJSON_NumberIsFormatted              (1 << 10)
+#define cJSON_NumberFormatStyleFixedPoint    (1 << 11)
+#define cJSON_NumberFormatStyleSet(g_format) ((g_format == true) ? 0 : cJSON_NumberFormatStyleFixedPoint) /* 0 for general, 1 for fixed point */
+#define cJSON_NumberFormatPrecisionShift     (12)   /* Position of the mask */
+#define cJSON_NumberFormatPrecisionMask      (0x3F) /* 0x3F is the maximum precision */
+#define cJSON_NumberFormatPrecision          (cJSON_NumberFormatPrecisionMask << cJSON_NumberFormatPrecisionShift)
+#define cJSON_NumberFormatPrecisionSet(x)    (((x) << cJSON_NumberFormatPrecisionShift) & cJSON_NumberFormatPrecision)
+#define cJSON_NumberFormatPrecisionGet(x)    (((x) >> cJSON_NumberFormatPrecisionShift) & cJSON_NumberFormatPrecisionMask)
+
+typedef int cJSON_bool;
 
 /* The cJSON structure: */
 typedef struct cJSON
@@ -128,8 +139,6 @@ typedef struct cJSON_Hooks
       void *(CJSON_CDECL *malloc_fn)(size_t sz);
       void (CJSON_CDECL *free_fn)(void *ptr);
 } cJSON_Hooks;
-
-typedef int cJSON_bool;
 
 /* Limits how deeply nested arrays/objects can be before cJSON rejects to parse them.
  * This is to prevent stack overflows. */
@@ -284,6 +293,9 @@ CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number);
 #define cJSON_SetNumberValue(object, number) ((object != NULL) ? cJSON_SetNumberHelper(object, (double)number) : (number))
 /* Change the valuestring of a cJSON_String object, only takes effect when type of object is cJSON_String */
 CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring);
+
+/* Interface to set formatting options for numbers */
+CJSON_PUBLIC(void) cJSON_SetNumberFormat(cJSON *object, cJSON_bool general_format, int precision);
 
 /* If the object is not a boolean type this does nothing and returns cJSON_Invalid else it returns the new type*/
 #define cJSON_SetBoolValue(object, boolValue) ( \

--- a/tests/print_number.c
+++ b/tests/print_number.c
@@ -144,14 +144,16 @@ static void print_number_fixed_point(void)
     assert_print_number_with_precision("100", 100, false, 1);
     assert_print_number_with_precision("100.5", 100.5, false, 3);
     assert_print_number_with_precision("100", 100.5, false, 0);     /* Bankers rounding, to the nearest even */
-    /* assert_print_number_with_precision("102", 101.5, false, 0);     /1* Bankers rounding, to the nearest even *1/ */
-    /* assert_print_number_with_precision("100.2", 100.15, false, 1);  /1* Bankers rounding, to the nearest even *1/ */
-    /* assert_print_number_with_precision("100.2", 100.25, false, 1);  /1* Bankers rounding, to the nearest even *1/ */
-    /* assert_print_number_with_precision("0", -0.0123, false, 1); */
-    /* assert_print_number_with_precision("0", 0.0249, false, 1); */
-    /* assert_print_number_with_precision("-0.02", -0.0153454, false, 2); */
-    /* assert_print_number_with_precision("-0.05", -0.0453454, false, 2); */
-    /* assert_print_number_with_precision("0", -10e-10, false, 5); */
+    assert_print_number_with_precision("102", 101.5, false, 0);     /* Bankers rounding, to the nearest even */
+    assert_print_number_with_precision("100.2", 100.15, false, 1);  /* Bankers rounding, to the nearest even */
+    assert_print_number_with_precision("100.2", 100.25, false, 1);  /* Bankers rounding, to the nearest even */
+    assert_print_number_with_precision("0", -0.0123, false, 1);
+    assert_print_number_with_precision("0", 0.0249, false, 1);
+    assert_print_number_with_precision("-0.02", -0.0153454, false, 2);
+    assert_print_number_with_precision("-0.05", -0.0453454, false, 2);
+    assert_print_number_with_precision("0", -10e-10, false, 5);
+    assert_print_number_with_precision("-0.03", -0.029999999999999999, false, 2);
+    assert_print_number_with_precision("0.03", 0.029999999999999999, false, 2);
 }
 
 static void print_number_general_format(void)


### PR DESCRIPTION
This work allows to format floating point, either set the decimal point or significant number.  If not format preference are given then the driver behaves as before. 

Note that JSON specifies to print numbers in it's shortest form, this is still the case e.g. but a number will not be printed longer than e.g. a given decimal point. But a number that has been formatted with a decimal point won't be printed in a scientific notation.