### PR TITLE
Add support for QNX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ if (ENABLE_CUSTOM_COMPILER_FLAGS)
             -Wused-but-marked-unused
             -Wswitch-enum
         )
+        if(QNX)
+            list(REMOVE_ITEM custom_compiler_flags -std=c89)
+        endif()
     elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
         # Disable warning c4001 - nonstandard extension 'single line comment' was used
         # Define _CRT_SECURE_NO_WARNINGS to disable deprecation warnings for "insecure" C library functions
@@ -153,7 +156,7 @@ install(TARGETS "${CJSON_LIB}"
 )
 if (BUILD_SHARED_AND_STATIC_LIBS)
     install(TARGETS "${CJSON_LIB}-static"
-    EXPORT "${CJSON_LIB}" 
+    EXPORT "${CJSON_LIB}"
     ARCHIVE DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}"
     INCLUDES DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}"
 )
@@ -201,8 +204,8 @@ if(ENABLE_CJSON_UTILS)
         INCLUDES DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}"
     )
     if (BUILD_SHARED_AND_STATIC_LIBS)
-        install(TARGETS "${CJSON_UTILS_LIB}-static" 
-        EXPORT "${CJSON_UTILS_LIB}" 
+        install(TARGETS "${CJSON_UTILS_LIB}-static"
+        EXPORT "${CJSON_UTILS_LIB}"
         ARCHIVE DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}"
         INCLUDES DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}"
         )
@@ -254,6 +257,10 @@ if(ENABLE_CJSON_TEST)
         else()
             target_compile_options(${TEST_CJSON} PRIVATE "-fno-sanitize=float-divide-by-zero")
         endif()
+    endif()
+
+    if(QNX)
+        install(TARGETS "${TEST_CJSON}" DESTINATION bin/cJSON_tests)
     endif()
 
     #"check" target that automatically builds everything and runs the tests

--- a/test.c
+++ b/test.c
@@ -25,6 +25,10 @@
 #include <string.h>
 #include "cJSON.h"
 
+#ifdef __QNX__
+#error test
+#endif
+
 /* Used by some code below as an example datatype. */
 struct record
 {

--- a/test.c
+++ b/test.c
@@ -25,10 +25,6 @@
 #include <string.h>
 #include "cJSON.h"
 
-#ifdef __QNX__
-#error test
-#endif
-
 /* Used by some code below as an example datatype. */
 struct record
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,7 +95,6 @@ if(ENABLE_CJSON_TEST)
             PATTERN "*.cmake" EXCLUDE
             PATTERN "Makefile" EXCLUDE
             PATTERN "*.a" EXCLUDE
-            PATTERN "*.so" EXCLUDE
         )
     endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,6 +88,17 @@ if(ENABLE_CJSON_TEST)
 
     add_dependencies(check ${unity_tests})
 
+    if(QNX)
+        install(DIRECTORY ${PROJECT_BINARY_DIR}/tests/
+            DESTINATION bin/cJSON_tests
+            PATTERN "CMakeFiles" EXCLUDE
+            PATTERN "*.cmake" EXCLUDE
+            PATTERN "Makefile" EXCLUDE
+            PATTERN "*.a" EXCLUDE
+            PATTERN "*.so" EXCLUDE
+        )
+    endif()
+
     if (ENABLE_CJSON_UTILS)
         #copy test files
         file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/json-patch-tests")


### PR DESCRIPTION
The following changes allow for `cJSON` to be built for QNX 7.1 and 8.0 targets. 

Build and test instructions for QNX : https://github.com/qnx-ports/build-files/tree/main/ports/cJSON