### PR TITLE
Add strengthen the protection of strlen in cJSON_ParseWithOpts

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -1100,7 +1100,7 @@ CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return
 {
     size_t buffer_length;
 
-    if (NULL == value)
+    if (NULL == value || (*value != '[' && *value != '{'))
     {
         return NULL;
     }


### PR DESCRIPTION
Dear maintainer,

when using flash's mmap method to access json strings, can strengthen the protection of strlen when flash data is all 0xff