### PR TITLE
Update function print_value in cJSON.c

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -1386,7 +1386,15 @@ static cJSON_bool print_value(const cJSON * const item, printbuffer * const outp
             {
                 return false;
             }
-            strcpy((char*)output, "null");
+            //
+            // this modifications are made because the strcpy does not work in some cases
+            *output++ = 'n';
+            *output++ = 'u';
+            *output++ = 'l';
+            *output++ = 'l';
+            *output   = '\0';
+            // this does not work
+            //strcpy((char*)output, "null");
             return true;
 
         case cJSON_False:
@@ -1395,7 +1403,16 @@ static cJSON_bool print_value(const cJSON * const item, printbuffer * const outp
             {
                 return false;
             }
-            strcpy((char*)output, "false");
+            //
+            // this modifications are made because the strcpy does not work in some cases
+            *output++ = 'f';
+            *output++ = 'a';
+            *output++ = 'l';
+            *output++ = 's';
+            *output++ = 'e';
+            *output   = '\0';
+            // this does not work
+            //strcpy((char*)output, "false");
             return true;
 
         case cJSON_True:
@@ -1404,7 +1421,15 @@ static cJSON_bool print_value(const cJSON * const item, printbuffer * const outp
             {
                 return false;
             }
-            strcpy((char*)output, "true");
+            //
+            // this modifications are made because the strcpy does not work in some cases
+            *output++ = 't';
+            *output++ = 'r';
+            *output++ = 'u';
+            *output++ = 'e';
+            *output   = '\0';
+            // this does not work
+            //strcpy((char*)output, "true");
             return true;
 
         case cJSON_Number:


### PR DESCRIPTION

Changes to the function:
static cJSON_bool print_value(const cJSON * const item, printbuffer * const output_buffer)

The function: strcpy((char*)output, "false") causes memory crashes in ThreadX(at least in my case). The modification delivers the same results but without the crash.