### PR TITLE
fix: raise CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(cJSON
     VERSION 1.7.18


### PR DESCRIPTION
The previous minimum version was set to 3.0, which was deprecated in CMake 4.0. This caused build failures for users with newer versions of CMake.

Previously, building the project with CMake 4.0 would fail due to the line:
`cmake_minimum_required(VERSION 3.0)`

This is now bumped to 3.5 to match the new compatibility requirements.

Fixes #946