### PR TITLE
update max_policy version of cmake to 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...4.0)
 
 project(cJSON
     VERSION 1.7.18


### PR DESCRIPTION
update max_policy version of cmake to 4.0

this allows users with newer versions of cmake to compile the project
(since versions below 3.5 are deprecated as of right now)

cmake 3.0 is still supported

closes #946
closes #942
