### PR TITLE
Fix potential bug in test file

### DIFF
--- a/fuzzing/cjson_read_fuzzer.c
+++ b/fuzzing/cjson_read_fuzzer.c
@@ -57,7 +57,11 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     if(minify)
     {
         copied = (unsigned char*)malloc(size);
-        if(copied == NULL) return 0;
+        if(copied == NULL) 
+        {
+            cJSON_Delete(json);
+            return 0;
+        }
 
         memcpy(copied, data, size);
 

--- a/fuzzing/fuzz_main.c
+++ b/fuzzing/fuzz_main.c
@@ -8,7 +8,7 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size); /* required by C89
 
 int main(int argc, char **argv)
 {
-    FILE *f;
+    FILE *f = NULL;
     char *buf = NULL;
     long siz_buf;
 
@@ -25,7 +25,10 @@ int main(int argc, char **argv)
         goto err;
     }
 
-    fseek(f, 0, SEEK_END);
+    if(fseek(f, 0, SEEK_END) != 0) {
+        fprintf(stderr, "fseek() to end failed\n");
+        goto err;
+    }
 
     siz_buf = ftell(f);
     rewind(f);
@@ -49,6 +52,10 @@ int main(int argc, char **argv)
 
 err:
     free(buf);
+    if (f != NULL)
+    {
+        fclose(f);
+    }
 
     return 0;
 }

--- a/test.c
+++ b/test.c
@@ -51,6 +51,10 @@ static int print_preallocated(cJSON *root)
 
     /* formatted print */
     out = cJSON_Print(root);
+    if (out == NULL) {
+        printf("Failed to print cJSON object.\n");
+        return -1;
+    }
 
     /* create buffer to succeed */
     /* the extra 5 bytes are because of inaccuracies when reserving memory */
@@ -59,6 +63,7 @@ static int print_preallocated(cJSON *root)
     if (buf == NULL)
     {
         printf("Failed to allocate memory.\n");
+        free(out);
         exit(1);
     }
 
@@ -68,6 +73,8 @@ static int print_preallocated(cJSON *root)
     if (buf_fail == NULL)
     {
         printf("Failed to allocate memory.\n");
+        free(out);
+        free(buf);
         exit(1);
     }
 

--- a/tests/common.h
+++ b/tests/common.h
@@ -27,7 +27,12 @@
 
 void reset(cJSON *item);
 void reset(cJSON *item) {
-    if ((item != NULL) && (item->child != NULL))
+    if (item == NULL)
+    {
+        return;
+    }
+
+    if (item->child != NULL)
     {
         cJSON_Delete(item->child);
     }

--- a/tests/json_patch_tests.c
+++ b/tests/json_patch_tests.c
@@ -157,7 +157,10 @@ static cJSON_bool test_generate_test(cJSON *test)
     TEST_ASSERT_NOT_NULL_MESSAGE(patch, "Failed to generate patches.");
 
     printed_patch = cJSON_Print(patch);
-    printf("%s\n", printed_patch);
+    if (printed_patch)
+    {
+        printf("%s\n", printed_patch);
+    }
     free(printed_patch);
 
     /* apply the generated patch */


### PR DESCRIPTION
All the bugs detected can be checked easily.

### first commit

> this commit fixes the file descriptor leak.

There exists a potential file descriptor leak in `fuzz_main.c`, which `fopen` a file but forget to `fclose` it.

### second commit

> this commit fixes the null pointer dereference and memory leak.

In the function `cJSON_Print`, `NULL` value may be returned, we need to take care of this case. 
What's more, before `exit` the program, we should free the resource as more as we can.

### third commit

> this commit fixes the potential memory leak

### 4th commit

> this commit fixes the potential Null Pointer Dereference