### PR TITLE
Add null pointer check in cJSON_ReplaceItemInObjectCaseSensitive

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -2439,6 +2439,9 @@ CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObject(cJSON *object, const char *st
 
 CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object, const char *string, cJSON *newitem)
 {
+    if (newitem == NULL) {
+        return false;
+    }
     return replace_item_in_object(object, string, newitem, true);
 }
 


### PR DESCRIPTION
A heap-use-after-free error occurs in the test case below when trying to replace an item in a JSON object with a cJSON item that has already been freed. The ASan report clearly shows that we're attempting to read from memory that was previously freed.

The function should validate the newitem parameter before using it. 

**Test Case:**
TEST_F(cJSONReplaceItemTest, UseAfterFree) {
    cJSON* temp_item = cJSON_CreateString("temp");
    cJSON_Delete(temp_item);
    EXPECT_FALSE(cJSON_ReplaceItemInObjectCaseSensitive(root, "key", temp_item));
}