### PR TITLE
Add a cJSON_AddNumberToObject object check

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -2182,6 +2182,10 @@ CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * co
 
 CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number)
 {
+    if ((object == NULL) || !cJSON_IsObject(object)) {
+        return NULL;
+    }
+    
     cJSON *number_item = cJSON_CreateNumber(number);
     if (add_item_to_object(object, name, number_item, &global_hooks, false))
     {


### PR DESCRIPTION
cJSON_AddNumberToObject doesn't validate the input object type before proceeding. The function should validate the input object type first. 