### PR TITLE
fix decode_pointer_inplace to handle escape sequences correctly

### DIFF
--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -371,18 +371,23 @@ static void decode_pointer_inplace(unsigned char *string)
             if (string[1] == '0')
             {
                 decoded_string[0] = '~';
+                string++;
             }
             else if (string[1] == '1')
             {
-                decoded_string[1] = '/';
+                decoded_string[0] = '/';
+                string++;
             }
             else
             {
                 /* invalid escape sequence */
+                *decoded_string = '\0';
                 return;
             }
-
-            string++;
+        }
+        else
+        {
+            decoded_string[0] = string[0];
         }
     }
 


### PR DESCRIPTION
This pull request make fix to the `decode_pointer_inplace` function in `cJSON_Utils.c` to correct how escape sequences are decoded