### PR TITLE
Fix: add depth check to prevent stack overflow in cJSON_Print

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -1598,6 +1598,11 @@ static cJSON_bool print_array(const cJSON * const item, printbuffer * const outp
         return false;
     }
 
+    if (output_buffer->depth >= CJSON_NESTING_LIMIT)
+    {
+        return false; /* nesting is too deep */
+    }
+
     /* Compose the output array. */
     /* opening square bracket */
     output_pointer = ensure(output_buffer, 1);
@@ -1776,6 +1781,11 @@ static cJSON_bool print_object(const cJSON * const item, printbuffer * const out
     if (output_buffer == NULL)
     {
         return false;
+    }
+
+    if (output_buffer->depth >= CJSON_NESTING_LIMIT)
+    {
+        return false; /* nesting is too deep */
     }
 
     /* Compose the output: */


### PR DESCRIPTION
## Problem
Currently, `cJSON_Parse` enforces a depth limit (`CJSON_NESTING_LIMIT`) to prevent stack overflows during parsing. However, the `cJSON_Print` (and its internal `print_array` / `print_object` functions) does not check this limit.

If a cJSON structure is constructed with a depth exceeding the stack size (e.g., via internal API manipulation or deep recursion), calling `cJSON_Print` results in a stack overflow (SIGSEGV) rather than failing gracefully.

## Solution
This PR adds a depth check to `print_array` and `print_object`, mirroring the logic already present in `cJSON_Parse`.

* Added a check: `if (output_buffer->depth >= CJSON_NESTING_LIMIT)` at the beginning of `print_array` and `print_object`.
* If the depth limit is reached, the function now returns `false`, causing `cJSON_Print` to return `NULL` gracefully instead of crashing the application.

## Impact
* **Safety:** Prevents crashes when printing deeply nested objects.
* **Consistency:** Aligns the behavior of the printer with the parser regarding nesting limits.
* **Performance:** Minimal impact (two integer comparisons per node).

## Verification
I have tested this with a constructed cJSON object exceeding `CJSON_NESTING_LIMIT`.
* **Before:** Segmentation fault.
* **After:** `cJSON_Print` returns `NULL`.

As discussed with the maintainers, this is submitted as a robustness fix to handle edge cases in internal API usage.