### PR TITLE
Fix: incorrect ~1 decoding in decode_pointer_inplace

### DIFF
--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -374,7 +374,7 @@ static void decode_pointer_inplace(unsigned char *string)
             }
             else if (string[1] == '1')
             {
-                decoded_string[1] = '/';
+                decoded_string[0] = '/';
             }
             else
             {

--- a/tests/misc_utils_tests.c
+++ b/tests/misc_utils_tests.c
@@ -29,6 +29,29 @@
 #include "common.h"
 #include "../cJSON_Utils.h"
 
+static void decode_pointer_inplace_should_decode_tilde_one_to_forward_slash(void)
+{
+    /* A key whose name contains a literal '/' must be addressed in a JSON
+     * Pointer using the ~1 escape sequence (RFC 6901).  A previous bug wrote
+     * '/' to decoded_string[1] instead of decoded_string[0], leaving '~' in
+     * place and producing "~/" instead of "/". */
+    cJSON *object = cJSON_Parse("{\"foo/bar\": 1}");
+    cJSON *patch = cJSON_Parse("[{\"op\": \"replace\", \"path\": \"/foo~1bar\", \"value\": 2}]");
+    cJSON *item = NULL;
+
+    TEST_ASSERT_NOT_NULL(object);
+    TEST_ASSERT_NOT_NULL(patch);
+
+    TEST_ASSERT_EQUAL_INT(0, cJSONUtils_ApplyPatches(object, patch));
+
+    item = cJSON_GetObjectItemCaseSensitive(object, "foo/bar");
+    TEST_ASSERT_NOT_NULL_MESSAGE(item, "Key \"foo/bar\" not found after patch with ~1 path.");
+    TEST_ASSERT_EQUAL_DOUBLE(2.0, item->valuedouble);
+
+    cJSON_Delete(object);
+    cJSON_Delete(patch);
+}
+
 static void cjson_utils_functions_shouldnt_crash_with_null_pointers(void)
 {
     cJSON *item = cJSON_CreateString("item");
@@ -74,6 +97,7 @@ int main(void)
 {
     UNITY_BEGIN();
 
+    RUN_TEST(decode_pointer_inplace_should_decode_tilde_one_to_forward_slash);
     RUN_TEST(cjson_utils_functions_shouldnt_crash_with_null_pointers);
 
     return UNITY_END();


### PR DESCRIPTION
Bug: 
`decode_pointer_inplace` in `cJSON_Utils.c` incorrectly decoded the `~1` 
escape sequence (RFC 6901 JSON Pointer, representing `/`).
The write target was off by one:
```c
/* before */
decoded_string[1] = '/';
/* after */
decoded_string[0] = '/';
```
This left the original ~ in place, producing ~/ instead of /. As a
result, any JSON Patch operation (add, remove, replace, move, copy)
whose "path" contained a ~1 sequence would silently target the wrong key.

Fix:
Changed decoded_string[1] to decoded_string[0] so the decoded / is
written to the correct position.

A unit test has been added to tests/misc_utils_tests.c that applies a
replace patch targeting a key with a literal / in its name via a ~1
path, and verifies the correct key is updated.