### PR TITLE
fuzzing: add cjson_print_roundtrip_fuzzer for print/serialize paths

### DIFF
--- a/fuzzing/cjson_print_roundtrip_fuzzer.c
+++ b/fuzzing/cjson_print_roundtrip_fuzzer.c
@@ -1,0 +1,80 @@
+/*
+ * cjson_print_roundtrip_fuzzer.c
+ *
+ * Fuzz harness for cJSON print/serialize paths and parse->print->parse
+ * round-trip consistency. Exercises:
+ *   - cJSON_ParseWithLength() with arbitrary length mismatch
+ *   - cJSON_PrintUnformatted() serialization of parsed trees
+ *   - cJSON_PrintBuffered() with small prebuf to force reallocation
+ *   - Round-trip: parse -> print -> re-parse (checks serializer output is valid)
+ *   - cJSON_Print() (formatted) on the same tree
+ *   - cJSON_Duplicate() for deep trees
+ *
+ * Build: compiled by fuzzing/ossfuzz.sh alongside cjson_read_fuzzer.
+ */
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "../cJSON.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size); /* required by C89 */
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    cJSON *obj = NULL;
+    cJSON *reparsed = NULL;
+    cJSON *dup = NULL;
+    char *unformatted = NULL;
+    char *formatted = NULL;
+    char *buffered = NULL;
+
+    if (size == 0)
+        return 0;
+
+    /* 1. Parse with explicit length (may differ from null-termination) */
+    obj = cJSON_ParseWithLength((const char *)data, size);
+    if (obj == NULL)
+        return 0;
+
+    /* 2. Print unformatted */
+    unformatted = cJSON_PrintUnformatted(obj);
+    if (unformatted != NULL) {
+        /* 3. Round-trip: re-parse the printed output */
+        reparsed = cJSON_Parse(unformatted);
+        if (reparsed != NULL) {
+            cJSON_Delete(reparsed);
+        }
+        free(unformatted);
+    }
+
+    /* 4. Print formatted */
+    formatted = cJSON_Print(obj);
+    if (formatted != NULL) {
+        free(formatted);
+    }
+
+    /* 5. PrintBuffered with small prebuf to exercise realloc path */
+    buffered = cJSON_PrintBuffered(obj, 16, cJSON_False);
+    if (buffered != NULL) {
+        free(buffered);
+    }
+
+    /* 6. Also exercise cJSON_Duplicate for deep trees */
+    dup = cJSON_Duplicate(obj, cJSON_True);
+    if (dup != NULL) {
+        cJSON_Delete(dup);
+    }
+
+    cJSON_Delete(obj);
+    return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/fuzzing/ossfuzz.sh
+++ b/fuzzing/ossfuzz.sh
@@ -12,6 +12,10 @@ $CXX $CXXFLAGS $SRC/cjson/fuzzing/cjson_read_fuzzer.c -I. \
     -o $OUT/cjson_read_fuzzer \
     $LIB_FUZZING_ENGINE $SRC/cjson/build/libcjson.a
 
+$CXX $CXXFLAGS $SRC/cjson/fuzzing/cjson_print_roundtrip_fuzzer.c -I. \
+    -o $OUT/cjson_print_roundtrip_fuzzer \
+    $LIB_FUZZING_ENGINE $SRC/cjson/build/libcjson.a
+
 find $SRC/cjson/fuzzing/inputs -name "*" | \
      xargs zip $OUT/cjson_read_fuzzer_seed_corpus.zip
 


### PR DESCRIPTION
## Summary

Adds a new libFuzzer harness for cJSON's serialization (print) code paths, which are currently unexercised by OSS-Fuzz.

### New harness: `fuzzing/cjson_print_roundtrip_fuzzer.c`

**Coverage added:**
- `cJSON_ParseWithLength()` — parse with explicit length (catches boundary bugs)
- `cJSON_PrintUnformatted()` — compact serialization of parsed trees
- `cJSON_Print()` — formatted serialization
- `cJSON_PrintBuffered()` with 16-byte prebuf — forces internal buffer reallocation
- `cJSON_Duplicate()` — deep copy exercises recursive tree traversal
- **Round-trip**: parse → print → re-parse (verifies serializer output is valid JSON)

### Why this matters
The existing `cjson_read_fuzzer` only calls `cJSON_Parse()`. The print/serialize code paths allocate and grow heap buffers dynamically and are reachable whenever a caller serializes a cJSON tree. A parse-triggered deep/wide tree fed into `cJSON_Print()` could trigger integer overflows in buffer size calculations.

### Build
Integrates with the existing `fuzzing/ossfuzz.sh` — one new `$CC` line added.