### PR TITLE
Limit numeric token length during parsing

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -351,6 +351,10 @@ static cJSON_bool parse_number(cJSON * const item, parse_buffer * const input_bu
             default:
                 goto loop_end;
         }
+        if (number_string_length > CJSON_NUMBER_LENGTH_LIMIT)
+        {
+            return false;
+        }
     }
 loop_end:
     /* malloc for temporary buffer, add 1 for '\0' */

--- a/cJSON.h
+++ b/cJSON.h
@@ -99,6 +99,10 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 #define cJSON_IsReference 256
 #define cJSON_StringIsConst 512
 
+#ifndef CJSON_NUMBER_LENGTH_LIMIT
+#define CJSON_NUMBER_LENGTH_LIMIT 512
+#endif
+
 /* The cJSON structure: */
 typedef struct cJSON
 {


### PR DESCRIPTION
`parse_number()` copies the numeric token into a temporary null-terminated buffer before passing it to `strtod()`. Currently, the token length is bounded only by the remaining input size, so unusually long numeric tokens can lead to
large temporary allocations.

This change rejects numeric tokens longer than `CJSON_NUMBER_LENGTH_LIMIT` before allocating the temporary number string.