### PR TITLE
Fix #1009, reject empty array reference token in decode_array_index_from_pointer

### DIFF
--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -276,6 +276,12 @@ static cJSON_bool decode_array_index_from_pointer(const unsigned char * const po
     size_t parsed_index = 0;
     size_t position = 0;
 
+    if ((pointer[0] == '\0') || (pointer[0] == '/'))
+    {
+        /* an empty reference token is not a valid array index */
+        return 0;
+    }
+
     if ((pointer[0] == '0') && ((pointer[1] != '\0') && (pointer[1] != '/')))
     {
         /* leading zeroes are not permitted */

--- a/tests/json-patch-tests/cjson-utils-tests.json
+++ b/tests/json-patch-tests/cjson-utils-tests.json
@@ -87,5 +87,17 @@
         "doc": {"foo": {"bar": 1}},
         "patch": [{"op": "add", "path": "/foo/bar/baz", "value": "5"}],
         "error": "attempting to add to subfield of non-object"
-    } 
+    },
+    {
+        "comment": "16, an empty reference token is not a valid array index",
+        "doc": [ "first", "second", "third" ],
+        "patch": [{ "op": "remove", "path": "/" }],
+        "error": "an empty reference token is not a valid array index"
+    },
+    {
+        "comment": "17, an empty reference token is not a valid array index",
+        "doc": [ "first", "second", "third" ],
+        "patch": [{ "op": "replace", "path": "/", "value": "x" }],
+        "error": "an empty reference token is not a valid array index"
+    }
 ]

--- a/tests/old_utils_tests.c
+++ b/tests/old_utils_tests.c
@@ -85,6 +85,28 @@ static void json_pointer_tests(void)
     cJSON_Delete(root);
 }
 
+static void json_pointer_should_reject_empty_array_index(void)
+{
+    /* An empty reference token is not a valid array index (RFC 6901), so it
+     * must not be silently accepted as index 0. */
+    cJSON *array = cJSON_Parse("[\"first\", \"second\", \"third\"]");
+    cJSON *nested = cJSON_Parse("[[1, 2], [3, 4]]");
+
+    TEST_ASSERT_NOT_NULL(array);
+    TEST_ASSERT_NOT_NULL(nested);
+
+    /* valid array indices still resolve */
+    TEST_ASSERT_EQUAL_PTR(cJSONUtils_GetPointer(array, "/0"), cJSON_GetArrayItem(array, 0));
+    TEST_ASSERT_EQUAL_PTR(cJSONUtils_GetPointer(nested, "/0/1"), cJSON_GetArrayItem(cJSON_GetArrayItem(nested, 0), 1));
+
+    /* an empty array reference token must be rejected, not resolved to index 0 */
+    TEST_ASSERT_NULL(cJSONUtils_GetPointer(array, "/"));
+    TEST_ASSERT_NULL(cJSONUtils_GetPointer(nested, "/0/"));
+
+    cJSON_Delete(array);
+    cJSON_Delete(nested);
+}
+
 static void misc_tests(void)
 {
     /* Misc tests */
@@ -216,6 +238,7 @@ int main(void)
     UNITY_BEGIN();
 
     RUN_TEST(json_pointer_tests);
+    RUN_TEST(json_pointer_should_reject_empty_array_index);
     RUN_TEST(misc_tests);
     RUN_TEST(sort_tests);
     RUN_TEST(merge_tests);


### PR DESCRIPTION
## Problem

`decode_array_index_from_pointer()` accepts an empty reference token and decodes it as index `0`, which is not valid per [RFC 6901, section 4](https://www.rfc-editor.org/rfc/rfc6901#section-4): when the referenced value is an array, the token must be either a non-negative integer without leading zeroes or `-`. An empty string is not a valid array index.

Because `get_item_from_pointer()` (and the JSON Patch code) call this whenever the current value is an array, invalid pointers containing an empty array token silently resolve to the first element:

```c
cJSONUtils_GetPointer(array,  "/");   /* returned array[0],     should be NULL */
cJSONUtils_GetPointer(nested, "/0/"); /* returned nested[0][0], should be NULL */
```

The same empty token also made JSON Patch operate on `array[0]` for paths that are not valid array locations, although RFC 6902 requires such operations to fail:

```json
[{ "op": "remove",  "path": "/" }]                 // removed the first element
[{ "op": "replace", "path": "/", "value": "x" }]   // replaced the first element
[{ "op": "move",    "from": "/", "path": "/1" }]   // detached the first element
```

## Fix

Reject an empty reference token (first character `'\0'` or `'/'`) at the top of `decode_array_index_from_pointer()`, before the index is parsed. It is a cheap, local guard, consistent with the existing leading-zero check just below it.

This only affects **array** index decoding. The valid empty-string **object** key (e.g. `"/"` applied to an object, or a trailing slash on a nested object) is intentionally left untouched, because that path never goes through array index decoding — the existing `old_utils_tests.c` and `tests.json` cases for it still pass.

## Verification

- Added a regression test `json_pointer_should_reject_empty_array_index` in `tests/old_utils_tests.c`, next to the existing JSON Pointer tests, plus two JSON Patch cases in `tests/json-patch-tests/cjson-utils-tests.json` (`remove`/`replace` with path `"/"` on an array must fail). All of them fail before this change and pass after it.
- Full test suite passes under GCC and Clang with `-DENABLE_CJSON_UTILS=ON -DENABLE_SANITIZERS=ON` (22/22, ASan/UBSan clean).
- `cJSON_Utils.c` compiles cleanly under the strict warning set (`-Werror -Wconversion -Wc++-compat -pedantic -std=c89`).

Fixes #1009
