### PR TITLE
fix: prevent NULL valuestring dereference in cJSONUtils_ApplyPatches

### DIFF
--- a/cJSON_Utils.c
+++ b/cJSON_Utils.c
@@ -742,7 +742,7 @@ enum patch_operation { INVALID, ADD, REMOVE, REPLACE, MOVE, COPY, TEST };
 static enum patch_operation decode_patch_operation(const cJSON * const patch, const cJSON_bool case_sensitive)
 {
     cJSON *operation = get_object_item(patch, "op", case_sensitive);
-    if (!cJSON_IsString(operation))
+    if (!cJSON_IsString(operation) || (operation->valuestring == NULL))
     {
         return INVALID;
     }
@@ -815,7 +815,7 @@ static int apply_patch(cJSON *object, const cJSON *patch, const cJSON_bool case_
     int status = 0;
 
     path = get_object_item(patch, "path", case_sensitive);
-    if (!cJSON_IsString(path))
+    if (!cJSON_IsString(path) || (path->valuestring == NULL))
     {
         /* malformed patch. */
         status = 2;
@@ -906,7 +906,7 @@ static int apply_patch(cJSON *object, const cJSON *patch, const cJSON_bool case_
     if ((opcode == MOVE) || (opcode == COPY))
     {
         cJSON *from = get_object_item(patch, "from", case_sensitive);
-        if (!cJSON_IsString(from))
+        if (!cJSON_IsString(from) || (from->valuestring == NULL))
         {
             /* missing "from" for copy/move. */
             status = 4;

--- a/tests/misc_utils_tests.c
+++ b/tests/misc_utils_tests.c
@@ -70,11 +70,66 @@ static void cjson_utils_functions_shouldnt_crash_with_null_pointers(void)
     cJSON_Delete(item);
 }
 
+static void cjson_utils_apply_patches_should_reject_null_valuestring(void)
+{
+    /* A cJSON_String item can have a NULL valuestring (e.g. when created with
+     * cJSON_CreateStringReference(NULL)). The JSON patch code checks the "op",
+     * "path" and "from" fields with cJSON_IsString() and then dereferences
+     * valuestring. Such patches must be rejected with an error code instead of
+     * crashing on the NULL valuestring. */
+
+    /* NULL "op" valuestring */
+    {
+        cJSON *object = cJSON_CreateObject();
+        cJSON *patches = cJSON_CreateArray();
+        cJSON *patch = cJSON_CreateObject();
+        cJSON_AddItemToObject(patch, "op", cJSON_CreateStringReference(NULL));
+        cJSON_AddItemToObject(patch, "path", cJSON_CreateString(""));
+        cJSON_AddItemToObject(patch, "value", cJSON_CreateNumber(1));
+        cJSON_AddItemToArray(patches, patch);
+        TEST_ASSERT_TRUE_MESSAGE(0 != cJSONUtils_ApplyPatches(object, patches), "NULL \"op\" valuestring should be rejected.");
+        TEST_ASSERT_TRUE_MESSAGE(0 != cJSONUtils_ApplyPatchesCaseSensitive(object, patches), "NULL \"op\" valuestring should be rejected.");
+        cJSON_Delete(object);
+        cJSON_Delete(patches);
+    }
+
+    /* NULL "path" valuestring */
+    {
+        cJSON *object = cJSON_CreateObject();
+        cJSON *patches = cJSON_CreateArray();
+        cJSON *patch = cJSON_CreateObject();
+        cJSON_AddItemToObject(patch, "op", cJSON_CreateString("remove"));
+        cJSON_AddItemToObject(patch, "path", cJSON_CreateStringReference(NULL));
+        cJSON_AddItemToArray(patches, patch);
+        TEST_ASSERT_TRUE_MESSAGE(0 != cJSONUtils_ApplyPatches(object, patches), "NULL \"path\" valuestring should be rejected.");
+        TEST_ASSERT_TRUE_MESSAGE(0 != cJSONUtils_ApplyPatchesCaseSensitive(object, patches), "NULL \"path\" valuestring should be rejected.");
+        cJSON_Delete(object);
+        cJSON_Delete(patches);
+    }
+
+    /* NULL "from" valuestring */
+    {
+        cJSON *object = cJSON_CreateObject();
+        cJSON *patches = cJSON_CreateArray();
+        cJSON *patch = cJSON_CreateObject();
+        cJSON_AddItemToObject(object, "a", cJSON_CreateNumber(1));
+        cJSON_AddItemToObject(patch, "op", cJSON_CreateString("move"));
+        cJSON_AddItemToObject(patch, "path", cJSON_CreateString("/b"));
+        cJSON_AddItemToObject(patch, "from", cJSON_CreateStringReference(NULL));
+        cJSON_AddItemToArray(patches, patch);
+        TEST_ASSERT_TRUE_MESSAGE(0 != cJSONUtils_ApplyPatches(object, patches), "NULL \"from\" valuestring should be rejected.");
+        TEST_ASSERT_TRUE_MESSAGE(0 != cJSONUtils_ApplyPatchesCaseSensitive(object, patches), "NULL \"from\" valuestring should be rejected.");
+        cJSON_Delete(object);
+        cJSON_Delete(patches);
+    }
+}
+
 int main(void)
 {
     UNITY_BEGIN();
 
     RUN_TEST(cjson_utils_functions_shouldnt_crash_with_null_pointers);
+    RUN_TEST(cjson_utils_apply_patches_should_reject_null_valuestring);
 
     return UNITY_END();
 }


### PR DESCRIPTION
### Description
`cJSONUtils_ApplyPatches`/`...CaseSensitive` can crash with a NULL pointer dereference when a patch contains a `cJSON_String` field whose `valuestring` is `NULL`, instead of rejecting the malformed patch.

### Root cause
The patch code validates the `op`, `path` and `from` fields with `cJSON_IsString()`, which only checks the type tag (`(type & 0xFF) == cJSON_String`) and does **not** guarantee `valuestring != NULL`. A string item with a NULL `valuestring` is reachable through the public API (e.g. `cJSON_CreateStringReference(NULL)`), so it passes the check and is then dereferenced:

- `decode_patch_operation()` → `strcmp(operation->valuestring, ...)`
- `apply_patch()` → `path->valuestring[0]` / `detach_path(..., path->valuestring)`
- `apply_patch()` → `detach_path()` / `get_item_from_pointer(..., from->valuestring)`

This continues the hardening from #1006, which tightened the same `from` check from `== NULL` to `!cJSON_IsString(from)`.

### Fix
Reject a NULL `valuestring` alongside the existing `cJSON_IsString()` checks for `op`, `path` and `from`, so the affected patches return the existing malformed-patch error codes (`3` / `2` / `4`) instead of crashing — consistent with how other invalid patches are already handled.

### Verification
- Added a regression test `cjson_utils_apply_patches_should_reject_null_valuestring` in `tests/misc_utils_tests.c` covering all three fields (the three PoCs from the issue). It crashes (NULL deref) on `master` and passes with this change.
- Ran the full suite locally across the CI matrix — GCC **and** Clang × {`ENABLE_SANITIZERS`, `ENABLE_VALGRIND`, none}: **22/22 tests pass**, 0 warnings under `-std=c89 -pedantic -Werror -Wconversion`, and valgrind reports no leaks/errors.

Fixes #1011
